### PR TITLE
Fix mapping of PDButton

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ jobs:
       run: tar -xvzf PlaydateSDK-latest.tar.gz
     - name: Local publish playdate
       run: nimble develop
+    - name: Tests
+      run: |
+        export PLAYDATE_SDK_PATH=$(readlink -f $(find PlaydateSDK-* -maxdepth 0 -type d));
+        nimble test;
     - name: Setup
       run: |
         export PLAYDATE_SDK_PATH=$(readlink -f $(find PlaydateSDK-* -maxdepth 0 -type d));

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Ignore test binaries
+tests/t_*
+!tests/t_*.*

--- a/playdate_example/src/playdate_example.nim
+++ b/playdate_example/src/playdate_example.nim
@@ -21,16 +21,16 @@ proc update(): int =
     # playdate is the global PlaydateAPI instance, available when playdate/api is imported
     let buttonsState = playdate.system.getButtonsState()
 
-    if buttonsState.current.check(kButtonRight):
+    if kButtonRight in buttonsState.current:
         x += 10
-    if buttonsState.current.check(kButtonLeft):
+    if kButtonLeft in buttonsState.current:
         x -= 10
-    if buttonsState.current.check(kButtonUp):
+    if kButtonUp in buttonsState.current:
         y -= 10
-    if buttonsState.current.check(kButtonDown):
+    if kButtonDown in buttonsState.current:
         y += 10
 
-    if buttonsState.pushed.check(kButtonA):
+    if kButtonA in buttonsState.pushed:
         samplePlayer.play(1, 1.0)
 
     let goalX = x.toFloat

--- a/src/playdate/bindings/system.nim
+++ b/src/playdate/bindings/system.nim
@@ -4,11 +4,10 @@ import utils
 import types
 
 type PDButton* {.importc: "PDButtons", header: "pd_api.h", size: sizeof(uint32).} = enum
-    kButtonLeft = (1 shl 0), kButtonRight = (1 shl 1), kButtonUp = (1 shl 2),
-    kButtonDown = (1 shl 3), kButtonB = (1 shl 4), kButtonA = (1 shl 5)
+    kButtonLeft = 1, kButtonRight = 2, kButtonUp = 3,
+    kButtonDown = 4, kButtonB = 5, kButtonA = 6
+
 type PDButtons* = set[PDButton]
-proc check*(this: PDButtons, button: PDButton): bool =
-    return (cast[uint32](this) and cast[uint32](button)) != 0
 
 type PDLanguage* {.importc: "PDLanguage", header: "pd_api.h".} = enum
     kPDLanguageEnglish, kPDLanguageJapanese, kPDLanguageUnknown
@@ -46,8 +45,8 @@ sdktype:
         getSecondsSinceEpoch {.importc: "getSecondsSinceEpoch".}: proc (milliseconds: ptr cuint): cuint {.cdecl, raises: [].}
         drawFPS {.importsdk.}: proc (x: cint; y: cint)
         setUpdateCallback {.importc: "setUpdateCallback".}: proc (update: PDCallbackFunctionRaw, userdata: pointer) {.cdecl, raises: [].}
-        getButtonState {.importc: "getButtonState".}: proc (current: ptr PDButton;
-            pushed: ptr PDButton; released: ptr PDButton) {.cdecl, raises: [].}
+        getButtonState {.importc: "getButtonState".}: proc (current: ptr uint32;
+            pushed: ptr uint32; released: ptr uint32) {.cdecl, raises: [].}
         setPeripheralsEnabled* {.importc.}: proc (mask: PDPeripherals) {.cdecl, raises: [].}
         getAccelerometer {.importc: "getAccelerometer".}: proc (outx: ptr cfloat;
             outy: ptr cfloat; outz: ptr cfloat) {.cdecl, raises: [].}

--- a/src/playdate/build/nimble.nim
+++ b/src/playdate/build/nimble.nim
@@ -26,7 +26,7 @@ proc pdxName(): string =
 
 const SDK_ENV_VAR = "PLAYDATE_SDK_PATH"
 
-proc sdkPath(): string =
+proc sdkPath*(): string =
     ## Returns the path of the playdate SDK
     let fromEnv = getEnv(SDK_ENV_VAR)
     let sdkPathCache = getConfigDir() / projectName() / SDK_ENV_VAR

--- a/src/playdate/system.nim
+++ b/src/playdate/system.nim
@@ -48,9 +48,9 @@ proc setUpdateCallback*(this: ptr PlaydateSys, update: PDCallbackFunction) =
 
 proc getButtonsState* (this: ptr PlaydateSys): tuple[current: PDButtons, pushed: PDButtons, released: PDButtons] =
     privateAccess(PlaydateSys)
-    var current, pushed, released: PDButtons
-    this.getButtonState(cast[ptr PDButton](addr(current)), cast[ptr PDButton](addr(pushed)), cast[ptr PDButton](addr(released)))
-    return (current: current, pushed: pushed, released: released)
+    var current, pushed, released: uint32
+    this.getButtonState(addr(current), addr(pushed), addr(released))
+    return (current: cast[PDButtons](current), pushed: cast[PDButtons](pushed), released: cast[PDButtons](released))
 
 proc getAccelerometer* (this: ptr PlaydateSys): tuple[x: float, y: float, z: float] =
     privateAccess(PlaydateSys)

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,0 +1,5 @@
+import ../src/playdate/build/nimble
+switch("compileOnly", "off")
+switch("noMain", "off")
+switch("path", "$projectDir/../src")
+switch("passC", "-I" & sdkPath() & "/C_API -DTARGET_EXTENSION=1")

--- a/tests/t_buttons.nim
+++ b/tests/t_buttons.nim
@@ -1,0 +1,21 @@
+import unittest, playdate/api
+
+suite "Button press detection":
+
+    let buttons = [
+        kButtonLeft:  0b0000_0001,
+        kButtonRight: 0b0000_0010,
+        kButtonUp:    0b0000_0100,
+        kButtonDown:  0b0000_1000,
+        kButtonB:     0b0001_0000,
+        kButtonA:     0b0010_0000,
+    ]
+
+    for testButton, bitfield in buttons:
+        test "Detecting " & $testButton:
+            let buttons = cast[PDButtons](bitfield)
+            for button in low(PDButton)..high(PDButton):
+                if button == testButton:
+                    check(button in buttons)
+                else:
+                    check(button notin buttons)

--- a/tests/t_smoketest.nim
+++ b/tests/t_smoketest.nim
@@ -1,0 +1,6 @@
+import unittest, playdate/api
+
+suite "Smoke test":
+    test "Importing the playdate API":
+        # Test passes because this file compiled
+        discard


### PR DESCRIPTION
PDButtons is not currently behaving like a real Nim set. This change fixes that behavior, and also adds unit tests
    
Nim appears to already map enum values to a bitfield by doing a `shl` internally. Doing the `shl` in the binding code was forcing a "double encoding" problem. This was causing set operations against `PDButtons` to fail silently.
    
This change also removes the 'check' function, since we can now use regular Nim set operations. For example, we could just do:

```nim
kButtonA in buttons
````

Note that the unit tests were added as a separate commit. If you would like them as a separate PR, let me know