### PR TITLE
Add wrapApi macro

### DIFF
--- a/src/playdate/bindings/graphics.nim
+++ b/src/playdate/bindings/graphics.nim
@@ -218,3 +218,7 @@ sdktype:
             tile: cint) {.cdecl, raises: [].}   ##  1.12
         makeFontFromData {.importc: "makeFontFromData".}: proc (data: LCDFontDataPtr;
             wide: cint): LCDFontPtr {.cdecl, raises: [].}
+
+proc toLCDFontGlyphPtr*(this: LCDFontGlyph): auto = this.resource
+
+proc toLCDFontPtr*(this: LCDFont): auto = this.resource

--- a/src/playdate/bindings/system.nim
+++ b/src/playdate/bindings/system.nim
@@ -24,6 +24,8 @@ type
     PDMenuItemOptions* = ref object of PDMenuItem
         callback*: proc(menuItem: PDMenuItemOptions) {.raises: [].}
 
+proc toPDMenuItemPtr*(this: PDMenuItem): auto = this.resource
+
 type PDPeripherals* {.importc: "PDPeripherals", header: "pd_api.h".} = enum
     kNone = 0, kAccelerometer = (1 shl 0), kAllPeripherals = 0xffff
 

--- a/src/playdate/bindings/utils.nim
+++ b/src/playdate/bindings/utils.nim
@@ -1,4 +1,4 @@
-import macros
+import macros, options
 
 proc realloc*(p: pointer, size: csize_t): pointer {.importc: "realloc", cdecl.}
 
@@ -33,12 +33,12 @@ func toNimReturn(typeSymbol: string, call: NimNode): seq[NimNode] =
 
 func adjustRawProcIdentDef(identDef: NimNode, rawProcName: string, procName: string): NimNode =
     let identDef = identDef.copy()
-    
+
     var pragmas = identDef.findChild(it.kind == nnkProcTy)
         .findChild(it.kind == nnkPragma)
     if pragmas == nil:
         pragmas = nnkPragma.newTree()
-    
+
     var toAddPragmas = newSeq[NimNode]()
     for pragma in pragmas:
         # Removing invalid pragmas.
@@ -90,7 +90,7 @@ proc generateSDKPtrProcDef*(rawProcDef: NimNode, rawProcName: string, typeName: 
             newIdentNode(rawProcName)
         )
     )
-    
+
     let fromPragmas = rawProcDef[1].findChild(it.kind == nnkPragma)
     if fromPragmas != nil:
         for pragma in fromPragmas.items:
@@ -106,7 +106,7 @@ proc generateSDKPtrProcDef*(rawProcDef: NimNode, rawProcName: string, typeName: 
         newProcPragmas = newEmptyNode()
 
     let fromParams = rawProcDef[1].findChild(it.kind == nnkFormalParams)
-        
+
     # Prepare arguments and return type of the new proc and of the inner call.
     for param in fromParams.items:
         if param.kind == nnkEmpty:
@@ -154,7 +154,7 @@ proc generateSDKPtrProcDef*(rawProcDef: NimNode, rawProcName: string, typeName: 
                 newIdentNode(typeSymbol),
                 newEmptyNode()
             )
-            
+
             newCall.add(argExpr)
             newProcParams.add(identDefs)
 
@@ -213,7 +213,7 @@ proc processSDKType(ast: NimNode): NimNode =
     var recList = newAst[0][0]
         .findChild(it.kind == nnkObjectTy)
         .findChild(it.kind == nnkRecList)
-    
+
     for index, identDef in recList:
         # echo "id ", index, " first child type ", identDef[0].kind
         if identDef[0].kind == nnkPragmaExpr:
@@ -250,3 +250,179 @@ proc processSDKType(ast: NimNode): NimNode =
 
 macro sdktype*(ast: untyped): untyped =
     return processSDKType(ast)
+
+proc propName(node: NimNode): string =
+    ## Returns the name of an object property, given the IdentDef node of that ojbect
+    case node.kind
+    of nnkIdentDefs, nnkPragmaExpr:
+        return node[0].propName
+    of nnkPostfix:
+        if node[0].propName == "*":
+            return node[1].propName
+    of nnkIdent:
+        return node.strVal
+    else: discard
+    error("Could not determine node name for: " & node.lispRepr, node)
+
+proc findObjectProp(objType: NimNode, name: string): NimNode =
+    ## Searches an object type definition to extract a specific property
+    case objType.kind
+    of nnkObjectTy:
+        for identDef in objType[2]:
+            if identDef.propName == name:
+                return identDef
+        error("Could not find a parameter named " & name, objType)
+    of nnkTypeDef:
+        return findObjectProp(objType[2], name)
+    else:
+        error("Node is not an object type: " & $objType.kind, objType)
+
+type Param = tuple[ident: NimNode, typ: NimNode]
+
+proc collectParams(procTy: NimNode): seq[Param] =
+    ## Returns a list of parameter names for a proc type.
+    for identDefs in procTy.params[1..^1]:
+        let typ = identDefs[^2]
+        for ident in identDefs[0..^3]:
+            result.add((ident, typ))
+
+proc unwrapType(typ: NimNode): NimNode =
+    ## Strips any wrapping annotations from a type to get down to the core type node. For example, removes
+    ## `var` and `ptr` prefixes.
+    case typ.kind
+    of nnkIdent, nnkSym: return typ
+    of nnkPtrTy, nnkVarTy: return typ[0].unwrapType
+    else: error("Unable to unwrap type: " & typ.lispRepr, typ)
+
+proc createCast(expression, inputType, outputType: NimNode): NimNode =
+    ## Creates a casting expression to convert a NimNode from one type to another.
+    if outputType.kind in { nnkIdent, nnkSym } and outputType.unwrapType.strVal != inputType.unwrapType.strVal:
+        return newCall("to_" & outputType.unwrapType.strVal, expression)
+    else:
+        return expression
+
+proc dotChain(props: varargs[string]): NimNode =
+    ## Given a list of strings, produce dot expressions that chain them. For example: playdate.sound.fileplayer.
+    for i, prop in props:
+        result = if i == 0: ident(prop) else: newDotExpr(result, ident(prop))
+
+proc getSdkRef(typ: NimNode): Option[NimNode] =
+    ## Given an SDK type node, returns the reference needed to access the global instance of that type
+    ## For example, given "PlaydateGraphics", returns "graphics".
+    case typ.unwrapType.strVal
+    of "PlaydateDisplay": return some(dotChain("playdate", "display"))
+    of "PlaydateGraphics": return some(dotChain("playdate", "graphics"))
+    of "PlaydateSys": return some(dotChain("playdate", "system"))
+    of "PlaydateSprite": return some(dotChain("playdate", "sprite"))
+    of "PlaydateSound": return some(dotChain("playdate", "sound"))
+    of "PlaydateSoundFileplayer": return some(dotChain("playdate", "sound", "fileplayer"))
+    of "PlaydateSoundSampleplayer": return some(dotChain("playdate", "sound", "sampleplayer"))
+    of "PlaydateSoundSample": return some(dotChain("playdate", "sound", "sample"))
+
+proc requireSdkRef(api: NimNode): NimNode =
+    ## Returns the global reference to an SDL type, or fails the build if it isn't available
+    let prop = api.getSdkRef
+    if prop.isSome:
+        return prop.unsafeGet
+    else:
+        error("Unrecognized API binding type: " & api.repr, api)
+
+proc getParamBinding(inputParams: seq[Param]): Option[Param] =
+    ## Examines a parameter list and determines whether the first parameter is a binding or not.
+    if inputParams.len > 0:
+        if inputParams[0].typ.getSdkRef.isSome:
+            return some(inputParams[0])
+
+proc buildApiCall(pdApiObjName, pdApiProcName, def: NimNode): NimNode =
+    ## Constructs a call to the wrapped API. Returns the call itself.
+    ## * `pdApiObjName` is the name of the SDK object this proc is a member of, for example `PlaydateGraphics`
+    ## * `pdApiProcName` is the name of the specific SDK proc being wrapped. For example, `logToConsole`
+    ## * `def` is the proc definition node for the external proc being created
+
+    pdApiObjName.expectKind(nnkSym)
+    pdApiProcName.expectKind(nnkIdent)
+    def.expectKind(nnkProcDef)
+
+    # Find the proc we're wrapping on the graphics API
+    let apiParam = pdApiObjName.getImpl.findObjectProp(pdApiProcName.strVal)
+
+    # Extract the type from the playdate API proc that we're wrapping
+    let apiProc = apiParam[^2]
+    apiProc.expectKind(nnkProcTy)
+
+    # A list of parameters from the public proc being defined
+    var inputParams = def.collectParams()
+
+    # Some of the public procs will include the "binding" object in the parameter set. For example,
+    # a parameter like `ptr PlaydateGraphics`. Other public procs will have a more specific binding, like
+    # `LCDSprite`, and need to manually reference the global binding instance (`playdate.graphics`).
+    let paramBinding = inputParams.getParamBinding
+    let bindTo = if paramBinding.isSome:
+        inputParams = inputParams[1..^1]
+        paramBinding.unsafeGet.ident
+    else:
+        pdApiObjName.requireSdkRef()
+
+    # Pass the parameters from the public function along to the Playdate internal API,
+    # while converting each parameter to the appropriate type
+    var args: seq[NimNode]
+    for i, apiParam in apiProc[0][1..^1]:
+        apiParam.expectKind(nnkIdentDefs)
+        args.add(createCast(inputParams[i].ident, inputParams[i].typ, apiParam[^2]))
+
+    result = newCall(newDotExpr(bindTo, pdApiProcName), args)
+
+    # If the API has a return type, we need to cast the return type to the output type of the proc
+    let apiReturnType = apiParam[1][0][0]
+    if apiReturnType.kind != nnkEmpty:
+        if def.params[0].kind == nnkEmpty:
+            result = nnkDiscardStmt.newTree(result)
+        else:
+            result = nnkReturnStmt.newTree(createCast(result, apiReturnType, def.params[0]))
+
+proc buildApiProc(apis: NimNode, pdApiProcName, def: NimNode): NimNode =
+    ## Constructs the public API proc based on the internal playdate API proc
+    def.body = newStmtList()
+
+    var apiList = if apis.kind == nnkSym: nnkBracketExpr.newTree(apis) else: apis
+
+    for api in apiList:
+        def.body.add quote do: privateAccess(`api`)
+
+    def.body.add(buildApiCall(apiList[0], pdApiProcName, def))
+    return def
+
+macro wrapApi*(pdApiObjNames: typed, pdApiProcName, def: untyped): untyped =
+    ## Wraps an API call
+    ## For example: `{.wrapApi(PlaydateSystem, logToConsole).}`
+    buildApiProc(pdApiObjNames, pdApiProcName, def)
+
+macro wrapApi*(pdApiObjNames: typed, def: untyped): untyped =
+    ## Wraps an API call that requires multiple permissions, where the name of the API is the name of the method.
+    ## For example: `{.wrapApi(PlaydateGraphics).}`
+    buildApiProc(pdApiObjNames, def.name, def)
+
+
+##
+## A bunch of common casting functions that are used by the automatically wrapped APIs
+##
+
+proc toCstring*(value: string): cstring = cstring(value)
+
+proc toBool*(value: cint): bool = value == 1
+
+proc toCint*(value: SomeInteger | bool): cint =
+    when value is bool: return if value: 1 else: 0
+    else: return cint(value)
+
+proc toCFloat*(value: SomeFloat): cfloat = cfloat(value)
+
+proc toString*(value: cstring): string = $value
+
+proc toInt*(value: cint): int = int(value)
+
+proc toUInt32*(value: char): uint32 = uint32(value)
+
+proc toUInt*(value: cint | SomeInteger): uint = uint(value)
+
+proc toFloat*(value: cfloat): float = float(value)

--- a/src/playdate/display.nim
+++ b/src/playdate/display.nim
@@ -2,17 +2,13 @@
 
 import std/importutils
 
-import bindings/display
+import bindings/[display, utils]
 
 # Only export public symbols, then import all
 export display
 {.hint[DuplicateModuleImport]: off.}
 import bindings/display {.all.}
 
-proc setInverted* (this: ptr PlaydateDisplay, inverted: bool) =
-    privateAccess(PlaydateDisplay)
-    this.setInverted(if inverted: 1 else: 0)
+proc setInverted* (this: ptr PlaydateDisplay, inverted: bool) {.wrapApi(PlaydateDisplay).}
 
-proc setFlipped* (this: ptr PlaydateDisplay, x: bool, y: bool) =
-    privateAccess(PlaydateDisplay)
-    this.setFlipped(if x: 1 else: 0, if y: 1 else: 0)
+proc setFlipped* (this: ptr PlaydateDisplay, x: bool, y: bool) {.wrapApi(PlaydateDisplay).}

--- a/src/playdate/sprite.nim
+++ b/src/playdate/sprite.nim
@@ -26,6 +26,8 @@ type
     LCDSpriteDrawFunction* = proc (sprite: LCDSprite; bounds: PDRect; drawRect: PDRect) {.closure, raises: [].}
     LCDSpriteUpdateFunction* = proc (sprite: LCDSprite) {.closure, raises: [].}
 
+proc toLCDSpritePtr(this: LCDSprite): auto = this.resource
+
 proc `=destroy`(this: var LCDSpriteObj) =
     privateAccess(PlaydateSprite)
     playdate.sprite.freeSprite(this.resource)
@@ -37,17 +39,11 @@ proc `=destroy`(this: var LCDSpriteObj) =
 
 var spritesData = initDoublyLinkedList[LCDSprite]()
 
-proc setAlwaysRedraw*(this: ptr PlaydateSprite, flag: bool) =
-    privateAccess(PlaydateSprite)
-    this.setAlwaysRedraw(if flag: 1 else: 0)
+proc setAlwaysRedraw*(this: ptr PlaydateSprite, flag: bool) {.wrapApi(PlaydateSprite).}
 
-proc moveTo*(this: LCDSprite, x: cfloat, y: cfloat) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.moveTo(this.resource, x, y)
+proc moveTo*(this: LCDSprite, x: cfloat, y: cfloat) {.wrapApi(PlaydateSprite).}
 
-proc moveBy*(this: LCDSprite, x: cfloat, y: cfloat) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.moveBy(this.resource, x, y)
+proc moveBy*(this: LCDSprite, x: cfloat, y: cfloat) {.wrapApi(PlaydateSprite).}
 
 # Sprites memory managament
 proc newSprite*(this: ptr PlaydateSprite): LCDSprite =
@@ -106,13 +102,9 @@ proc removeAllSprites*(this: ptr PlaydateSprite) =
         this.setUserdata(s.resource, nil)
     spritesData = initDoublyLinkedList[LCDSprite]()
 
-proc `bounds=`*(this: LCDSprite, bounds: PDRect) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setBounds(this.resource, bounds)
+proc `bounds=`*(this: LCDSprite, bounds: PDRect) {.wrapApi(PlaydateSprite, setBounds).}
 
-proc bounds*(this: LCDSprite): PDRect =
-    privateAccess(PlaydateSprite)
-    return playdate.sprite.getBounds(this.resource)
+proc bounds*(this: LCDSprite): PDRect {.wrapApi(PlaydateSprite, getBounds).}
 
 proc setImage*(this: LCDSprite, image: LCDBitmap, flip: LCDBitmapFlip) =
     privateAccess(PlaydateSprite)
@@ -124,89 +116,50 @@ proc getImage*(this: LCDSprite): LCDBitmap =
     privateAccess(PlaydateSprite)
     return this.bitmap
 
-proc setSize*(this: ptr PlaydateSprite, sprite: LCDSprite, width: float, height: float) =
-    privateAccess(PlaydateSprite)
-    this.setSize(sprite.resource, width.cfloat, height.cfloat)
+proc setSize*(this: ptr PlaydateSprite, sprite: LCDSprite, width: float, height: float)
+    {.wrapApi(PlaydateSprite).}
 
-proc `zIndex=`*(this: LCDSprite, zIndex: int16) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setZIndex(this.resource, zIndex)
+proc `zIndex=`*(this: LCDSprite, zIndex: int16) {.wrapApi(PlaydateSprite, setZIndex).}
 
-proc zIndex*(this: LCDSprite): int16 =
-    privateAccess(PlaydateSprite)
-    return playdate.sprite.getZIndex(this.resource)
+proc zIndex*(this: LCDSprite): int16 {.wrapApi(PlaydateSprite, getZIndex).}
 
-proc setDrawMode*(this: LCDSprite, mode: LCDBitmapDrawMode) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setDrawMode(this.resource, mode)
+proc setDrawMode*(this: LCDSprite, mode: LCDBitmapDrawMode) {.wrapApi(PlaydateSprite).}
 
-proc `imageFlip=`*(this: LCDSprite, flip: LCDBitmapFlip) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setImageFlip(this.resource, flip)
+proc `imageFlip=`*(this: LCDSprite, flip: LCDBitmapFlip) {.wrapApi(PlaydateSprite, setImageFlip).}
 
-proc imageFlip*(this: LCDSprite): LCDBitmapFlip =
-    privateAccess(PlaydateSprite)
-    return playdate.sprite.getImageFlip(this.resource)
+proc imageFlip*(this: LCDSprite): LCDBitmapFlip {.wrapApi(PlaydateSprite, getImageFlip).}
 
-proc setClipRect*(this: LCDSprite, clipRect: LCDRect) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setClipRect(this.resource, clipRect)
+proc setClipRect*(this: LCDSprite, clipRect: LCDRect) {.wrapApi(PlaydateSprite, setClipRect).}
 
-proc clearClipRect*(this: LCDSprite) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.clearClipRect(this.resource)
+proc clearClipRect*(this: LCDSprite) {.wrapApi(PlaydateSprite, clearClipRect).}
 
-proc setClipRectsInRange*(clipRect: LCDRect, startZ: int, endZ: int) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setClipRectsInRange(clipRect, startZ.cint, endZ.cint)
+proc setClipRectsInRange*(clipRect: LCDRect, startZ: int, endZ: int) {.wrapApi(PlaydateSprite).}
 
-proc clearClipRectsInRange*(startZ: int, endZ: int)=
-    privateAccess(PlaydateSprite)
-    playdate.sprite.clearClipRectsInRange(startZ.cint, endZ.cint)
+proc clearClipRectsInRange*(startZ: int, endZ: int) {.wrapApi(PlaydateSprite).}
 
-proc `updatesEnabled=`*(this: LCDSprite, enabled: bool) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setUpdatesEnabled(this.resource, if enabled: 1 else: 0)
+proc `updatesEnabled=`*(this: LCDSprite, enabled: bool) {.wrapApi(PlaydateSprite, setUpdatesEnabled).}
 
 proc updatesEnabled*(this: LCDSprite): bool =
     privateAccess(PlaydateSprite)
     return playdate.sprite.updatesEnabled(this.resource) > 0
 
-proc `collisionsEnabled=`*(this: LCDSprite, flag: bool) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setCollisionsEnabled(this.resource, if flag: 1 else: 0)
+proc `collisionsEnabled=`*(this: LCDSprite, flag: bool) {.wrapApi(PlaydateSprite, setCollisionsEnabled).}
 
-proc collisionsEnabled*(this: LCDSprite): bool =
-    privateAccess(PlaydateSprite)
-    return playdate.sprite.collisionsEnabled(this.resource) == 1
+proc collisionsEnabled*(this: LCDSprite): bool {.wrapApi(PlaydateSprite).}
 
-proc `visible=`*(this: LCDSprite, flag: bool) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setVisible(this.resource, if flag: 1 else: 0)
+proc `visible=`*(this: LCDSprite, flag: bool) {.wrapApi(PlaydateSprite, setVisible).}
 
-proc visible*(this: LCDSprite): bool =
-    privateAccess(PlaydateSprite)
-    return playdate.sprite.isVisible(this.resource) == 1
+proc visible*(this: LCDSprite): bool {.wrapApi(PlaydateSprite, isVisible).}
 
-proc setOpaque*(this: LCDSprite, flag: bool) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setOpaque(this.resource, if flag: 1 else: 0)
+proc setOpaque*(this: LCDSprite, flag: bool) {.wrapApi(PlaydateSprite).}
 
-proc markDirty*(this: LCDSprite) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.markDirty(this.resource)
+proc markDirty*(this: LCDSprite) {.wrapApi(PlaydateSprite).}
 
-proc `tag=`*(this: LCDSprite, tag: uint8) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setTag(this.resource, tag)
+proc `tag=`*(this: LCDSprite, tag: uint8) {.wrapApi(PlaydateSprite, setTag).}
 
-proc tag*(this: LCDSprite): uint8 =
-    privateAccess(PlaydateSprite)
-    return playdate.sprite.getTag(this.resource)
+proc tag*(this: LCDSprite): uint8 {.wrapApi(PlaydateSprite, getTag).}
 
-proc setIgnoresDrawOffset*(this: LCDSprite, flag: bool) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setIgnoresDrawOffset(this.resource, if flag: 1 else: 0)
+proc setIgnoresDrawOffset*(this: LCDSprite, flag: bool) {.wrapApi(PlaydateSprite).}
 
 # --- Update function.
 proc privateUpdateFunction(sprite: LCDSpritePtr) {.cdecl, exportc, raises: [].} =
@@ -240,17 +193,11 @@ proc getPosition*(this: LCDSprite): tuple[x: float, y: float] =
     return (x: x.float, y: y.float)
 
 
-proc `collideRect=`*(this: LCDSprite, collideRect: PDRect) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setCollideRect(this.resource, collideRect)
+proc `collideRect=`*(this: LCDSprite, collideRect: PDRect) {.wrapApi(PlaydateSprite, setCollideRect).}
 
-proc collideRect*(this: LCDSprite): PDRect =
-    privateAccess(PlaydateSprite)
-    return playdate.sprite.getCollideRect(this.resource)
+proc collideRect*(this: LCDSprite): PDRect {.wrapApi(PlaydateSprite, getCollideRect).}
 
-proc clearCollideRect*(this: LCDSprite) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.clearCollideRect(this.resource)
+proc clearCollideRect*(this: LCDSprite) {.wrapApi(PlaydateSprite, clearCollideRect).}
 
 # --- Collisions function.
 proc privateCollisionResponse(sprite: LCDSpritePtr; other: LCDSpritePtr): SpriteCollisionResponseType {.cdecl, exportc, raises: [].} =
@@ -387,9 +334,7 @@ proc allOverlappingSprites*(this: ptr PlaydateSprite): seq[LCDSprite] =
         result[i] = cast[ptr DoublyLinkedNodeObj[LCDSprite]](playdate.sprite.getUserdata(spr)).value
         i *= 1
 
-proc setStencilPattern*(this: LCDSprite, pattern: array[8, uint8]) =
-    privateAccess(PlaydateSprite)
-    playdate.sprite.setStencilPattern(this.resource, pattern)
+proc setStencilPattern*(this: LCDSprite, pattern: array[8, uint8]) {.wrapApi(PlaydateSprite).}
 
 proc clearStencil*(this: LCDSprite) =
     privateAccess(PlaydateSprite)

--- a/src/playdate/system.nim
+++ b/src/playdate/system.nim
@@ -4,7 +4,7 @@ import std/importutils
 import strformat
 import sequtils
 
-import bindings/[api, types]
+import bindings/[api, types, utils]
 import bindings/system
 
 # Only export public symbols, then import all
@@ -15,13 +15,9 @@ import bindings/system {.all.}
 template fmt*(arg: typed): string =
     try: &(arg) except: arg
 
-proc logToConsole*(this: ptr PlaydateSys, str: string) =
-    privateAccess(PlaydateSys)
-    this.logToConsole(str.cstring)
+proc logToConsole*(this: ptr PlaydateSys, str: string) {.wrapApi(PlaydateSys).}
 
-proc error*(this: ptr PlaydateSys, str: string) =
-    privateAccess(PlaydateSys)
-    this.error(str.cstring)
+proc error*(this: ptr PlaydateSys, str: string) {.wrapApi(PlaydateSys).}
 
 proc getSecondsSinceEpoch* (this: ptr PlaydateSys): tuple[seconds: uint, milliseconds: uint] =
     privateAccess(PlaydateSys)
@@ -58,21 +54,14 @@ proc getAccelerometer* (this: ptr PlaydateSys): tuple[x: float, y: float, z: flo
     this.getAccelerometer(addr(x), addr(y), addr(z))
     return (x: x.float, y: y.float, z: z.float)
 
-proc isCrankDocked* (this: ptr PlaydateSys): bool =
-    privateAccess(PlaydateSys)
-    return this.isCrankDocked() == 1
+proc isCrankDocked* (this: ptr PlaydateSys): bool {.wrapApi(PlaydateSys).}
 
-proc setCrankSoundsEnabled* (this: ptr PlaydateSys, enabled: bool): bool = ##  returns previous setting
-    privateAccess(PlaydateSys)
-    return this.setCrankSoundsDisabled(if enabled: 0 else: 1) == 0
+proc setCrankSoundsEnabled* (this: ptr PlaydateSys, enabled: bool): bool {.wrapApi(PlaydateSys, setCrankSoundsDisabled).}
+    ## returns previous setting
 
-proc getFlipped* (this: ptr PlaydateSys): bool =
-    privateAccess(PlaydateSys)
-    return this.getFlipped() == 1
+proc getFlipped* (this: ptr PlaydateSys): bool {.wrapApi(PlaydateSys).}
 
-proc setAutoLockEnabled* (this: ptr PlaydateSys, enabled: bool) =
-    privateAccess(PlaydateSys)
-    this.setAutoLockDisabled(if enabled: 0 else: 1)
+proc setAutoLockEnabled* (this: ptr PlaydateSys, enabled: bool) {.wrapApi(PlaydateSys, setAutoLockDisabled).}
 
 # --- Menu items
 privateAccess(PDMenuItem)
@@ -82,15 +71,9 @@ func isActive*(this: PDMenuItem): bool =
     privateAccess(PDMenuItem)
     return this.active
 
-proc `title=`*(this: PDMenuItem, title: string) =
-    privateAccess(PDMenuItem)
-    privateAccess(PlaydateSys)
-    playdate.system.setMenuItemTitle(this.resource, title.cstring)
+proc `title=`*(this: PDMenuItem, title: string) {.wrapApi(PlaydateSys, setMenuItemTitle).}
 
-proc title*(this: PDMenuItem): string =
-    privateAccess(PDMenuItem)
-    privateAccess(PlaydateSys)
-    return $playdate.system.getMenuItemTitle(this.resource)
+proc title*(this: PDMenuItem): string {.wrapApi(PlaydateSys, getMenuItemTitle).}
 
 proc remove*(this: PDMenuItem) =
     privateAccess(PDMenuItem)
@@ -109,25 +92,13 @@ proc remove*(this: PDMenuItem) =
 #     this.callback = nil
 #     this.PDMenuItem.remove()
 
-proc `value=`*(this: PDMenuItemCheckmark, checked: bool) =
-    privateAccess(PDMenuItem)
-    privateAccess(PlaydateSys)
-    playdate.system.setMenuItemValue(this.resource, if checked: 1 else: 0)
+proc `value=`*(this: PDMenuItemCheckmark, checked: bool) {.wrapApi(PlaydateSys, setMenuItemValue).}
 
-proc value*(this: PDMenuItemCheckmark): bool =
-    privateAccess(PDMenuItem)
-    privateAccess(PlaydateSys)
-    return playdate.system.getMenuItemValue(this.resource) == 1
+proc value*(this: PDMenuItemCheckmark): bool {.wrapApi(PlaydateSys, getMenuItemValue).}
 
-proc `value=`*(this: PDMenuItemOptions, index: int) =
-    privateAccess(PDMenuItem)
-    privateAccess(PlaydateSys)
-    playdate.system.setMenuItemValue(this.resource, index.cint)
+proc `value=`*(this: PDMenuItemOptions, index: int) {.wrapApi(PlaydateSys, setMenuItemValue).}
 
-proc value*(this: PDMenuItemOptions): int =
-    privateAccess(PDMenuItem)
-    privateAccess(PlaydateSys)
-    return playdate.system.getMenuItemValue(this.resource).int
+proc value*(this: PDMenuItemOptions): int {.wrapApi(PlaydateSys, getMenuItemValue).}
 
 type PDMenuItemButtonCallbackFunction* = proc(menuItem: PDMenuItemButton) {.raises: [].}
 type PDMenuItemCheckmarkCallbackFunction* = proc(menuItem: PDMenuItemCheckmark) {.raises: [].}
@@ -187,6 +158,4 @@ proc removeAllMenuItems*(this: ptr PlaydateSys) =
     this.removeAllMenuItems()
 # ---
 
-proc getReduceFlashing* (this: ptr PlaydateSys): bool =
-    privateAccess(PlaydateSys)
-    return this.getReduceFlashing() == 1
+proc getReduceFlashing* (this: ptr PlaydateSys): bool {.wrapApi(PlaydateSys).}


### PR DESCRIPTION
The wrapApi macro automatically generates the proc body for situations where a Playdate API method is just being directly invoked. The macro handles mapping input and output types automatically.

Before I continue down this path, is there an appetite for this? The benefit is that it removes undifferentiated code for the apis themselves, the downside is that it adds macro code that is more complicated than the undifferentiated code.