### PR TITLE
Better LCDColor support

### DIFF
--- a/playdate_example/src/playdate_example.nim
+++ b/playdate_example/src/playdate_example.nim
@@ -53,7 +53,6 @@ proc update(): int =
 
     return 1
 
-
 import std/json
 type
     Equip = ref object

--- a/src/playdate/graphics.nim
+++ b/src/playdate/graphics.nim
@@ -100,7 +100,7 @@ proc drawText*(this: ptr PlaydateGraphics, text: string, x: int, y: int): int {.
 
 proc newBitmap*(this: ptr PlaydateGraphics, width: int, height: int, color: LCDColor): LCDBitmap =
     privateAccess(PlaydateGraphics)
-    return LCDBitmap(resource: this.newBitmap(width.cint, height.cint, color), free: true)
+    return LCDBitmap(resource: this.newBitmap(width.cint, height.cint, color.convert), free: true)
 
 proc newBitmap*(this: ptr PlaydateGraphics, path: string): LCDBitmap {.raises: [IOError]} =
     privateAccess(PlaydateGraphics)
@@ -139,7 +139,7 @@ proc getData*(this: LCDBitmap): BitmapData =
 
 proc clear*(this: LCDBitmap, color: LCDColor) =
     privateAccess(PlaydateGraphics)
-    playdate.graphics.clearBitmap(this.resource, color)
+    playdate.graphics.clearBitmap(this.resource, color.convert)
 
 proc rotated*(this: LCDBitmap, rotation: float, xScale: float, yScale: float):
         tuple[bitmap: LCDBitmap, allocatedSize: int] =
@@ -284,10 +284,11 @@ proc copyFrameBufferBitmap*(this: ptr PlaydateGraphics): LCDBitmap =
     privateAccess(PlaydateGraphics)
     return LCDBitmap(resource: this.copyFrameBufferBitmap(), free: true)
 
-proc createPattern*(this: ptr PlaydateGraphics, bitmap: LCDBitmap, x: int, y: int): LCDColor =
+proc createPattern*(this: ptr PlaydateGraphics, bitmap: LCDBitmap, x: int, y: int): LCDPattern =
     privateAccess(PlaydateGraphics)
-    var color = 0.LCDColor
-    this.setColorToPattern(addr(color), bitmap.resource, x.cint, y.cint)
+    privateAccess(LCDPattern)
+    var color = new(LCDPattern)
+    this.setColorToPattern(addr color.pattern, bitmap.resource, x.cint, y.cint)
     return color
 
 import macros
@@ -296,7 +297,7 @@ proc fillPolygon*[Int32x2](this: ptr PlaydateGraphics, points: seq[Int32x2], col
     when sizeof(Int32x2) != sizeof(int32) * 2: {.error: "size of points is not sizeof(int32) * 2".}
 
     privateAccess(PlaydateGraphics)
-    this.fillPolygon(points.len.cint, cast[ptr cint](unsafeAddr(points[0])), color, fillRule)
+    this.fillPolygon(points.len.cint, cast[ptr cint](unsafeAddr(points[0])), color.convert, fillRule)
 
 proc getFontHeight*(this: LCDFont): uint =
     privateAccess(PlaydateGraphics)

--- a/tests/t_graphics.nim
+++ b/tests/t_graphics.nim
@@ -1,0 +1,31 @@
+import unittest, playdate/api
+
+suite "Graphics API":
+
+    template colorTests(value: untyped) =
+        # We can't run these methods from the tests, so we're only interested in
+        # whether they compile
+        if false:
+            let img = playdate.graphics.newBitmap(10, 10, value)
+            img.clear(value)
+
+            playdate.graphics.clear(value)
+            playdate.graphics.drawLine(0, 0, 10, 10, 2, value)
+            playdate.graphics.fillTriangle(0, 0, 10, 10, 0, 10, value)
+            playdate.graphics.drawRect(0, 0, 10, 10, value)
+            playdate.graphics.fillRect(0, 0, 10, 10, value)
+            playdate.graphics.drawEllipse(0, 0, 10, 10, 2, 0.0, 90.0, value)
+            playdate.graphics.fillEllipse(0, 0, 10, 10, 2, 0.0, value)
+            playdate.graphics.fillPolygon(@[0, 0, 10, 10, 0, 10], value, kPolygonFillEvenOdd)
+
+    test "Color methods could compile given a solid color":
+        colorTests(kColorWhite)
+
+    test "Color methods could compile given a pattern":
+        let pattern = makeLCDPattern(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+        colorTests(pattern)
+
+    test "Pattern creation should compile":
+        if false:
+            let img = playdate.graphics.newBitmap(10, 10, kColorWhite)
+            discard playdate.graphics.createPattern(img, 0, 0)


### PR DESCRIPTION
In the playdate API, LCDColor is defined as either a solid color or a pattern. This change models that explicitly to make it easier to pass in color values to APIs that expect them.