### PR TITLE
Export BitmapData.read

### DIFF
--- a/src/playdate/graphics.nim
+++ b/src/playdate/graphics.nim
@@ -130,7 +130,7 @@ type BitmapData* = ref object
 proc index(x, y, rowbytes: int): int = y * rowbytes + x div 8
     ## Returns the index of an (x, y) coordinate in a flattened array.
 
-template read(bitmap: BitmapData, x, y: int): untyped =
+template read*(bitmap: BitmapData, x, y: int): untyped =
     ## Read a pixel from a bitmap.
     assert(bitmap.data != nil)
     bitmap.data[index(x, y, bitmap.rowbytes)]


### PR DESCRIPTION
LCDBitmap.get(x,y) is very slow to sample pixel data, presumably because it extracts the bitmap data on every invocation.

When caching the BitmapData with LCDBitmap.getData and then invoking read on the BitmapData, we can sample pixel data at 93x the speed of  LCDBitmap.get(x,y)

benchmark, invocations per 100 ms. Higher is better:

LCDBitmap.get(0,0) - 513
 BitmapData.read(0,0) - 47716