### PR TITLE
Add setMany proc

### DIFF
--- a/tests/t_graphics.nim
+++ b/tests/t_graphics.nim
@@ -86,6 +86,38 @@ proc execGraphicsTests*(runnable: bool) =
                 img.set(0, 1, kColorClear)
                 check($img == "░█\n ░\n")
 
+        test "Bulk setting many pixels":
+            if runnable:
+                var img = playdate.graphics.newBitmap(6, 2, kColorWhite)
+                discard img.setBitmapMask()
+
+                img.setMany([
+                    [ kColorWhite, kColorBlack, kColorClear, kColorXOR, kColorWhite, kColorBlack, kColorClear, kColorXOR, ],
+                    [ kColorBlack, kColorClear, kColorXOR, kColorWhite, kColorBlack, kColorClear, kColorXOR, kColorWhite, ],
+                ])
+
+                check($img == "░█ █░█\n█ █░█ \n")
+
+        test "Bulk setting many pixels without a bit mask":
+            if runnable:
+                var img = playdate.graphics.newBitmap(6, 2, kColorWhite)
+
+                img.setMany([
+                    [ kColorWhite, kColorBlack, kColorXOR, kColorWhite, kColorBlack, kColorXOR, kColorWhite, kColorBlack, ],
+                    [ kColorBlack, kColorXOR, kColorWhite, kColorBlack, kColorXOR, kColorWhite, kColorBlack, kColorWhite, ],
+                ])
+
+                check($img == "░██░██\n██░██░\n")
+
+        test "Setting a clear pixel when there is no bitmask should fail":
+            if runnable:
+                var img = playdate.graphics.newBitmap(6, 2, kColorWhite)
+
+                expect AssertionDefect:
+                    img.setMany([
+                        [ kColorClear, kColorClear, kColorClear, kColorClear, kColorClear, kColorClear, kColorClear, kColorClear, ],
+                    ])
+
 when isMainModule:
     # We can't run these methods from the tests, so we're only interested in
     # whether they compile.


### PR DESCRIPTION
This function is a faster way to set many pixels in a bitmap, as compared to individually setting each pixel, while still being safe. The speed comes from a few mechanisms:

1. Centralized bounds checking
2. Single read from `getData`
3. Operating on reading and writing entire words instead of individual bits
4. Separating iteration over the primary bitmap and the mask to improve cache hits
5. ensuring that the input array is divisible by 8 to avoid any bounds checking within the loop

The big caveat is that I wrote this assuming the above mechanisms would be faster, but I didn't test each of those assertions separately. Nor have I examined the generated code. There is definitely still speed that can be wrought from this method if someone cares to tune it further. For example, there is definitely some unnecessary branching in the generated code that could probably be eliminated.