### PR TITLE
Dynamic PDX name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       # prompts so we can do a headless install
     - name: Force non-interactive apt installations
       run: echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-    
+
     - name: Update dependencies
       run: apt-get update
     - name: Install dependencies
@@ -107,4 +107,4 @@ jobs:
 
     - name: Run headless test
       working-directory: ./tests
-      run: xvfb-run ../PlaydateSDK-*/bin/PlaydateSimulator playdate.pdx
+      run: xvfb-run ../PlaydateSDK-*/bin/PlaydateSimulator tests.pdx

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Nim bindings
 .nim/
-build/
 nimcache/
 nimblecache/
 htmldocs/

--- a/playdate_example/.gitignore
+++ b/playdate_example/.gitignore
@@ -1,3 +1,3 @@
-playdate.pdx
+*.pdx
 source/pdex.*
 *.dSYM

--- a/playdate_example/.vscode/launch.json
+++ b/playdate_example/.vscode/launch.json
@@ -10,7 +10,7 @@
             "name": "Debug PDX",
             "program": "${env:PLAYDATE_SDK_PATH}/bin/Playdate Simulator",
             "args": [
-                "${workspaceFolder}/playdate.pdx"
+                "${workspaceFolder}/${workspaceFolderBasename}.pdx"
             ],
             "cwd": "${workspaceFolder}",
             "osx": {
@@ -33,7 +33,7 @@
             "program": "${env:PLAYDATE_SDK_PATH}/bin/Playdate Simulator",
             "preLaunchTask": "Build Universal PDX",
             "args": [
-                "${workspaceFolder}/playdate.pdx"
+                "${workspaceFolder}/${workspaceFolderBasename}.pdx"
             ],
             "cwd": "${workspaceFolder}",
             "osx": {
@@ -56,7 +56,7 @@
             "program": "${env:PLAYDATE_SDK_PATH}/bin/Playdate Simulator",
             "preLaunchTask": "Build Simulator PDX",
             "args": [
-                "${workspaceFolder}/playdate.pdx"
+                "${workspaceFolder}/${workspaceFolderBasename}.pdx"
             ],
             "cwd": "${workspaceFolder}",
             "osx": {

--- a/src/playdate/build/nimble.nim
+++ b/src/playdate/build/nimble.nim
@@ -9,8 +9,9 @@ when not compiles(task):
 
 
 proc bundlePDX() =
-    ## Bundles the pdx file
-    exec(pdcPath() & " --verbose -sdkpath " & sdkPath() & " source playdate")
+    ## Bundles pdx file using parent directory name.
+    exec(pdcPath() & " --verbose -sdkpath " & sdkPath() & " source " &
+      thisDir().splitPath.tail)
 
 proc postBuild(target: Target) =
     ## Performs post-build cleanup and prepares files for bundling.

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,3 @@
-playdate.pdx
+*.pdx
 source/pdex.*
 *.dSYM


### PR DESCRIPTION
Closes #28, see discussion there for details. Note the gitignore `build` change; pretty sure that wasn't intentional before, but lmk if you'd prefer a different solution (or feel free to change yourself if you prefer).