### PR TITLE
ADD suppress cmake configuration dialog in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": false
+}


### PR DESCRIPTION
Not sure whether this is the c++ plugin or everyone gets this, but I think for us, the answer to the question of whether we want to setup cmake for this project is always "no"