### PR TITLE
ADD print pdc version

### DIFF
--- a/src/playdate/build/nimble.nim
+++ b/src/playdate/build/nimble.nim
@@ -10,6 +10,8 @@ when not compiles(task):
 
 proc bundlePDX() =
     ## Bundles pdx file using parent directory name.
+    echo("pdc version:")
+    exec(pdcPath() & " --version")
     exec(pdcPath() & " --verbose -sdkpath " & sdkPath() & " source " &
       thisDir().splitPath.tail)
 


### PR DESCRIPTION
Adds the pdc version when running bundlePDX. Useful sanity check after you've just upgraded the SDK or are using experimental builds of pdc