### PR TITLE
Update workflow playdate ini path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       # alert from showing in the first place
     - name: Create simulator ini
       run: |
-        export PD_INI_DIR="$HOME/.Playdate Simulator"
+        export PD_INI_DIR="$HOME/.config/Playdate Simulator"
         mkdir -p "$PD_INI_DIR"
         export PD_INI_FILE="$PD_INI_DIR/Playdate Simulator.ini"
         echo "ShowPerfWarning=0" > $PD_INI_FILE


### PR DESCRIPTION
The 2.3.0 SDK release moved the location of the simulator ini file to conform to XDG locations. This change updates the build to use the new location

https://sdk.play.date/changelog/\#_2_3_0