### PR TITLE
CHANGE pdx name to use project name

### DIFF
--- a/src/playdate/build/utils.nim
+++ b/src/playdate/build/utils.nim
@@ -23,7 +23,7 @@ proc nimble*(args: varargs[string]) =
 
 proc pdxName*(): string =
     ## The name of the pdx file to generate
-    projectName() & ".pdx"
+    projectDir() & ".pdx"
 
 proc sdkPath*(): string =
     ## Returns the path of the playdate SDK

--- a/src/playdate/build/utils.nim
+++ b/src/playdate/build/utils.nim
@@ -23,7 +23,7 @@ proc nimble*(args: varargs[string]) =
 
 proc pdxName*(): string =
     ## The name of the pdx file to generate
-    "playdate" & ".pdx"
+    projectName() & ".pdx"
 
 proc sdkPath*(): string =
     ## Returns the path of the playdate SDK


### PR DESCRIPTION
This changes the pdx name from a hardcoded "playdate.pdx" to "wheelsprung.pdx" in my case.

For me, this fixes the `simulate` task. But perhaps that's because I changed the pdx name somewhere else, too?

Note that the example project also uses workspaceFolderBaseName in launch.json: [playdate_example/.vscode/launch.json](https://github.com/samdze/playdate-nim/blob/f664dda53d3bbe304326abf8f46f7e6bdb17725e/playdate_example/.vscode/launch.json#L13)