### PR TITLE
Nim 2 support

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -1,4 +1,7 @@
 name: Common build setup
+inputs:
+  nim-version:
+    required: true
 runs:
   using: "composite"
   steps:
@@ -6,6 +9,21 @@ runs:
     - name: Git safe directory
       shell: bash
       run: git config --global --add safe.directory "$(pwd)"
+
+    - name: Install Nim
+      shell: bash
+      run: choosenim -y update ${{ inputs.nim-version }}
+
+    - run: nimble --accept refresh
+      shell: bash
+
+    - run: nimble install
+      shell: bash
+
+    - name: Locally publish playdate nimble package
+      shell: bash
+      if: ${{ startsWith(inputs.nim-version, '1.') }}
+      run: nimble develop
 
     # Some of the apt dependencies require input from the installer. This disables those
     # prompts so we can do a headless install
@@ -28,7 +46,3 @@ runs:
     - name: Set PLAYDATE_SDK_PATH
       shell: bash
       run: echo "PLAYDATE_SDK_PATH=$(readlink -f $(find PlaydateSDK-* -maxdepth 0 -type d))" >> "$GITHUB_ENV"
-
-    - name: Locally publish playdate nimble package
-      shell: bash
-      run: nimble develop

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -1,0 +1,34 @@
+name: Common build setup
+runs:
+  using: "composite"
+  steps:
+
+    - name: Git safe directory
+      shell: bash
+      run: git config --global --add safe.directory "$(pwd)"
+
+    # Some of the apt dependencies require input from the installer. This disables those
+    # prompts so we can do a headless install
+    - name: Force non-interactive apt installations
+      shell: bash
+      run: echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+    - name: Update Apt dependencies
+      shell: bash
+      run: apt-get update
+
+    - name: Install apt dependencies
+      shell: bash
+      run: apt-get install -y libpng16-16 gcc-arm-none-eabi wget
+
+    - name: Download playdate SDK
+      shell: bash
+      run: wget -qO- https://download.panic.com/playdate_sdk/linux/playdatesdk-latest.tar.gz | tar xvz
+
+    - name: Set PLAYDATE_SDK_PATH
+      shell: bash
+      run: echo "PLAYDATE_SDK_PATH=$(readlink -f $(find PlaydateSDK-* -maxdepth 0 -type d))" >> "$GITHUB_ENV"
+
+    - name: Locally publish playdate nimble package
+      shell: bash
+      run: nimble develop

--- a/.github/actions/project-setup/action.yml
+++ b/.github/actions/project-setup/action.yml
@@ -1,0 +1,17 @@
+name: Common setup steps for a playdate nimble project
+inputs:
+  working-directory:
+    required: true
+runs:
+  using: "composite"
+  steps:
+
+    - name: Nimble example setup
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: nimble configure;
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: nimble install --depsOnly --accept

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,16 @@ jobs:
 
   example-project:
     runs-on: ubuntu-latest
-    container: nimlang/nim
+    container: nimlang/choosenim
     strategy:
       matrix:
         target: [ device, simulator ]
+        nim-version: [ 1.6.16, 2.0.2 ]
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/build-setup
+      with:
+        nim-version: ${{ matrix.nim-version }}
     - uses: ./.github/actions/project-setup
       with:
         working-directory: ./playdate_example
@@ -19,21 +22,31 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    container: nimlang/nim
+    container: nimlang/choosenim
+    strategy:
+      matrix:
+        nim-version: [ 1.6.16, 2.0.2 ]
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/build-setup
+      with:
+        nim-version: ${{ matrix.nim-version }}
     - run: nimble test
 
   headless-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    container: nimlang/nim
+    container: nimlang/choosenim
+    strategy:
+      matrix:
+        nim-version: [ 1.6.16, 2.0.2 ]
     steps:
 
     - uses: actions/checkout@v3
 
     - uses: ./.github/actions/build-setup
+      with:
+        nim-version: ${{ matrix.nim-version }}
 
     - uses: ./.github/actions/project-setup
       with:
@@ -46,6 +59,7 @@ jobs:
       # of warnings to be emitted. This set of commands sets up a dummy audio sink that silences those warnings.
     - name: Setup audio sink
       run: |
+        export HOME="/config"
         pulseaudio -D --exit-idle-time=-1
         pactl load-module module-null-sink sink_name=SpeakerOutput sink_properties=device.description="Dummy_Output"
 
@@ -57,12 +71,15 @@ jobs:
       # alert from showing in the first place
     - name: Create simulator ini
       run: |
-        export PD_INI_DIR="$HOME/.config/Playdate Simulator"
+        export PD_INI_DIR="/config/.config/Playdate Simulator"
         mkdir -p "$PD_INI_DIR"
         export PD_INI_FILE="$PD_INI_DIR/Playdate Simulator.ini"
         echo "ShowPerfWarning=0" > $PD_INI_FILE
         echo "ShowElist=0" >> $PD_INI_FILE
         echo "LastRelease=$(cat PlaydateSDK-*/VERSION.txt)" >> $PD_INI_FILE
 
-    - run: xvfb-run ../PlaydateSDK-*/bin/PlaydateSimulator tests.pdx
+    - name: Run headless test
       working-directory: ./tests
+      run: |
+        export HOME="/config"
+        xvfb-run ../PlaydateSDK-*/bin/PlaydateSimulator tests.pdx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         export PLAYDATE_SDK_PATH=$(readlink -f $(find PlaydateSDK-* -maxdepth 0 -type d));
         cd playdate_example;
-        nimble setup;
+        nimble playdateSetup;
     - name: Install dependencies
       working-directory: ./playdate_example
       run: nimble install --depsOnly --accept
@@ -87,7 +87,7 @@ jobs:
       run: |
         export PLAYDATE_SDK_PATH=$(readlink -f $(find PlaydateSDK-* -maxdepth 0 -type d));
         cd tests;
-        nimble setup;
+        nimble playdateSetup;
 
     - name: Compile for simulator
       working-directory: ./tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,63 +1,46 @@
 name: Build
 on: [push, pull_request]
 jobs:
-  build:
+
+  example-project:
+    runs-on: ubuntu-latest
+    container: nimlang/nim
+    strategy:
+      matrix:
+        target: [ device, simulator ]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/build-setup
+    - uses: ./.github/actions/project-setup
+      with:
+        working-directory: ./playdate_example
+    - run: nimble ${{ matrix.target }}
+      working-directory: ./playdate_example
+
+  tests:
     runs-on: ubuntu-latest
     container: nimlang/nim
     steps:
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/build-setup
+    - run: nimble test
 
-      # Some of the apt dependencies require input from the installer. This disables those
-      # prompts so we can do a headless install
-    - name: Force non-interactive apt installations
-      run: echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-
-    - name: Update dependencies
-      run: apt-get update
-    - name: Install dependencies
-      run: apt-get install -y libpng16-16 gcc-arm-none-eabi
-    - uses: actions/checkout@v1
-    - name: Download playdate SDK
-      run: wget https://download.panic.com/playdate_sdk/Linux/PlaydateSDK-latest.tar.gz
-    - name: Extract playdate SDK
-      run: tar -xvzf PlaydateSDK-latest.tar.gz
-    - name: Local publish playdate
-      run: nimble develop
-    - name: Tests
-      run: |
-        export PLAYDATE_SDK_PATH=$(readlink -f $(find PlaydateSDK-* -maxdepth 0 -type d));
-        nimble test;
-    - name: Setup
-      run: |
-        export PLAYDATE_SDK_PATH=$(readlink -f $(find PlaydateSDK-* -maxdepth 0 -type d));
-        cd playdate_example;
-        nimble playdateSetup;
-    - name: Install dependencies
-      working-directory: ./playdate_example
-      run: nimble install --depsOnly --accept
-    - name: Simulator
-      working-directory: ./playdate_example
-      run: nimble simulator
-    - name: Device
-      working-directory: ./playdate_example
-      run: nimble device
-
-  simulate:
+  headless-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     container: nimlang/nim
-    env:
-      HOME: /config
     steps:
 
-      # Some of the apt dependencies require input from the installer. This disables those
-      # prompts so we can do a headless install
-    - name: Force non-interactive apt installations
-      run: echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+    - uses: actions/checkout@v3
 
-    - name: Update dependencies
-      run: apt-get update
+    - uses: ./.github/actions/build-setup
+
+    - uses: ./.github/actions/project-setup
+      with:
+        working-directory: ./tests
+
     - name: Install dependencies
-      run: apt-get install -y libpng16-16 gcc-arm-none-eabi xvfb libgtk-3-0 sudo libwebkit2gtk-4.0 libwebkit2gtk-4.0-dev libsdl2-dev pulseaudio
+      run: apt-get install -y xvfb libgtk-3-0 sudo libwebkit2gtk-4.0 libwebkit2gtk-4.0-dev libsdl2-dev pulseaudio
 
       # Because we are headless there is no audio driver to interact with by default, which causes a set
       # of warnings to be emitted. This set of commands sets up a dummy audio sink that silences those warnings.
@@ -66,32 +49,8 @@ jobs:
         pulseaudio -D --exit-idle-time=-1
         pactl load-module module-null-sink sink_name=SpeakerOutput sink_properties=device.description="Dummy_Output"
 
-    - name: Checkout commit
-      uses: actions/checkout@v1
-
-    - name: Download playdate SDK
-      run: wget https://download.panic.com/playdate_sdk/Linux/PlaydateSDK-latest.tar.gz
-    - name: Extract playdate SDK
-      run: tar -xvzf PlaydateSDK-latest.tar.gz
-
-    - name: Local publish playdate
-      run: nimble develop
-
-    - name: Install dependencies
+    - run: nimble simulator
       working-directory: ./tests
-      run: nimble install --depsOnly --accept
-
-      # The tests need to be told where the SDK is. Running `setup` with the SDK path configured
-      # will fill that in
-    - name: Setup tests
-      run: |
-        export PLAYDATE_SDK_PATH=$(readlink -f $(find PlaydateSDK-* -maxdepth 0 -type d));
-        cd tests;
-        nimble playdateSetup;
-
-    - name: Compile for simulator
-      working-directory: ./tests
-      run: nimble simulator
 
       # The first time the simulator runs, it prompts the user with an alert. Obviously, we're running headless,
       # so this prevents the tests from running without closing that alert. Creating this ini file will stop that
@@ -105,6 +64,5 @@ jobs:
         echo "ShowElist=0" >> $PD_INI_FILE
         echo "LastRelease=$(cat PlaydateSDK-*/VERSION.txt)" >> $PD_INI_FILE
 
-    - name: Run headless test
+    - run: xvfb-run ../PlaydateSDK-*/bin/PlaydateSimulator tests.pdx
       working-directory: ./tests
-      run: xvfb-run ../PlaydateSDK-*/bin/PlaydateSimulator tests.pdx

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ echo 'include playdate/build/config' > config.nims;
 4. Finally, run this command to setup the structure of the project, which prepares your application to be compiled and bundled correctly:
 
 ```
-nimble setup
+nimble configure
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This package is an independent bindings library, not affiliated with Panic.
 ### Prerequisites
 
 - Playdate SDK
-- Nim 1.6.10+ (check with `nim -v`, untested with 2.0+) ([recommended extension for VSCode](https://marketplace.visualstudio.com/items?itemName=nimsaem.nimvscode))
+- Nim 1.6.10+ or Nim 2+ ([recommended extension for VSCode](https://marketplace.visualstudio.com/items?itemName=nimsaem.nimvscode))
 - Nimble 0.13.1 (check with `nimble -v`)
 - `PLAYDATE_SDK_PATH` environment variable
 - [SDK Prerequisites](https://sdk.play.date/Inside%20Playdate%20with%20C.html#_prerequisites) based on OS, and [MinGW on Windows](https://code.visualstudio.com/docs/cpp/config-mingw).

--- a/playdate_example/nimble.develop
+++ b/playdate_example/nimble.develop
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "includes": [],
+  "dependencies": [
+    ".."
+  ]
+}

--- a/src/playdate/build/nimble.nim
+++ b/src/playdate/build/nimble.nim
@@ -103,7 +103,7 @@ task all, "Build for both the simulator and the device":
     postBuild(Target.device)
     bundlePDX()
 
-task setup, "Initialize the build structure":
+task configure, "Initialize the build structure":
     ## Creates a default source directory if it doesn't already exist
 
     # Calling `sdkPath` will ensure the SDK environment variable is saved

--- a/src/playdate/build/nimble.nim
+++ b/src/playdate/build/nimble.nim
@@ -34,8 +34,7 @@ proc postBuild(target: Target) =
                 mvFile(projectName(), "source" / "pdex.elf")
             rmFile("game.map")
 
-
-task clean, "Clean the project files and folders":
+before clean:
     let args = taskArgs("clean")
     # Used to remove debug (_d) and release (_r) cache folders.
     let baseCacheDir = nimcacheDir()[0..^2]

--- a/tests/nimble.develop
+++ b/tests/nimble.develop
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "includes": [],
+  "dependencies": [
+    ".."
+  ]
+}


### PR DESCRIPTION
This change refactors the build scripts a bit to support building on both `1.6.14` and `2.0.2`, and adds support for building against Nim 2. The only thing that really needed to change was `switch("define", "useMalloc")`