### PR TITLE
Use playdate realloc for memory management

### DIFF
--- a/src/playdate/api.nim
+++ b/src/playdate/api.nim
@@ -3,7 +3,6 @@
 import macros
 import std/importutils
 
-import bindings/utils {.all.} as memory
 import bindings/api
 export api
 
@@ -17,9 +16,10 @@ macro initSDK*() =
         proc eventHandler(playdateAPI: ptr PlaydateAPI, event: PDSystemEvent, arg: uint32): cint {.cdecl, exportc.} =
             privateAccess(PlaydateSys)
             if event == kEventInit:
+                when declared(setupRealloc):
+                    setupRealloc(playdateAPI.system.realloc)
                 NimMain()
                 api.playdate = playdateAPI
-                memory.realloc = playdateAPI.system.realloc
             handler(event, arg)
             return 0
 

--- a/src/playdate/bindings/graphics.nim
+++ b/src/playdate/bindings/graphics.nim
@@ -73,8 +73,9 @@ type LCDBitmapTablePtr {.importc: "LCDBitmapTable*", header: "pd_api.h".} = poin
 type LCDFontPtr {.importc: "LCDFont*", header: "pd_api.h".} = pointer
 type LCDFontObj = object
     resource: LCDFontPtr
-proc `=destroy`(this: var LCDFontObj) =
-    discard utils.realloc(this.resource, 0)
+
+proc `=destroy`(this: var LCDFontObj) = deallocImpl(this.resource)
+
 type LCDFont* = ref LCDFontObj
 
 type LCDFontDataPtr {.importc: "LCDFontData*", header: "pd_api.h".} = object
@@ -83,15 +84,17 @@ type LCDFontData* = LCDFontDataPtr
 type LCDFontPagePtr {.importc: "LCDFontPage*", header: "pd_api.h".} = pointer
 type LCDFontPageObj = object
     resource: LCDFontPagePtr
-proc `=destroy`(this: var LCDFontPageObj) =
-    discard utils.realloc(this.resource, 0)
+
+proc `=destroy`(this: var LCDFontPageObj) = deallocImpl(this.resource)
+
 type LCDFontPage* = ref LCDFontPageObj
 
 type LCDFontGlyphPtr {.importc: "LCDFontGlyph*", header: "pd_api.h".} = pointer
 type LCDFontGlyphObj = object
     resource: LCDFontGlyphPtr
-proc `=destroy`(this: var LCDFontGlyphObj) =
-    discard utils.realloc(this.resource, 0)
+
+proc `=destroy`(this: var LCDFontGlyphObj) = deallocImpl(this.resource)
+
 type LCDFontGlyph* = ref LCDFontGlyphObj
 
 type LCDVideoPlayerRaw {.importc: "LCDVideoPlayer", header: "pd_api.h".} = object

--- a/src/playdate/bindings/malloc.nim
+++ b/src/playdate/bindings/malloc.nim
@@ -1,0 +1,72 @@
+##
+## This file is a re-implementation of malloc.nim in the Nim standard library.It allows Nim itself to use the
+## memory allocators provided by the playdate SDK.
+##
+## It works by by patching it in as a replacement in your configs.nim file, like this:
+##
+## ```nim
+## patchFile("stdlib", "malloc", nimblePlaydatePath / "src/playdate/bindings/malloc")
+## ```
+##
+## This patching is automatically configured when using `playdate/build/config`, as recommended by the setup
+## documentation.
+##
+
+{.push stackTrace: off.}
+
+when defined(memtrace):
+    import system/ansi_c
+
+type PDRealloc = proc (p: pointer; size: csize_t): pointer {.tags: [], raises: [], cdecl, gcsafe.}
+
+var pdrealloc: PDRealloc
+
+proc setupRealloc*(allocator: PDRealloc) =
+    when defined(memtrace):
+        cfprintf(cstderr, "Setting up playdate allocator")
+    pdrealloc = allocator
+
+proc allocImpl(size: Natural): pointer =
+    when defined(memtrace):
+        cfprintf(cstderr, "Allocating %d\n", size)
+    result = pdrealloc(nil, size.csize_t)
+    when defined(memtrace):
+        cfprintf(cstderr, "  At %p\n", result)
+
+proc alloc0Impl(size: Natural): pointer =
+    result = allocImpl(size)
+    zeroMem(result, size)
+
+proc reallocImpl(p: pointer, newSize: Natural): pointer =
+    when defined(memtrace):
+        cfprintf(cstderr, "Reallocating %p with size %d\n", p, newSize)
+    return pdrealloc(p, newSize.csize_t)
+
+proc realloc0Impl(p: pointer, oldsize, newSize: Natural): pointer =
+    result = realloc(p, newSize.csize_t)
+    if newSize > oldSize:
+        zeroMem(cast[pointer](cast[uint](result) + uint(oldSize)), newSize - oldSize)
+
+proc deallocImpl(p: pointer) =
+    when defined(memtrace):
+        cfprintf(cstderr, "Freeing %p\n", p)
+    discard pdrealloc(p, 0)
+
+# The shared allocators map on the regular ones
+
+proc allocSharedImpl(size: Natural): pointer {.used.} = allocImpl(size)
+
+proc allocShared0Impl(size: Natural): pointer {.used.} = alloc0Impl(size)
+
+proc reallocSharedImpl(p: pointer, newSize: Natural): pointer {.used.} = reallocImpl(p, newSize)
+
+proc reallocShared0Impl(p: pointer, oldsize, newSize: Natural): pointer {.used.} = realloc0Impl(p, oldSize, newSize)
+
+proc deallocSharedImpl(p: pointer) {.used.} = deallocImpl(p)
+
+proc getOccupiedMem(): int {.used.} = discard
+proc getFreeMem(): int {.used.} = discard
+proc getTotalMem(): int {.used.} = discard
+proc deallocOsPages() {.used.} = discard
+
+{.pop.}

--- a/src/playdate/bindings/system.nim
+++ b/src/playdate/bindings/system.nim
@@ -34,8 +34,7 @@ type PDMenuItemCallbackFunctionRaw {.importc: "PDMenuItemCallbackFunction", head
 # System
 sdktype:
     type PlaydateSys* {.importc: "const struct playdate_sys", header: "pd_api.h".} = object
-        realloc {.importc: "realloc".}: proc (`ptr`: pointer; size: csize_t): pointer {.
-            cdecl, raises: [].}
+        realloc {.importc: "realloc".}: proc (`ptr`: pointer; size: csize_t): pointer {.cdecl, raises: [], tags: [], gcsafe.}
         formatString {.importc: "formatString".}: proc (ret: cstringArray; fmt: cstring): cint {.
             cdecl, varargs, raises: [].}
         logToConsole {.importc: "logToConsole".}: proc (fmt: cstring) {.cdecl, varargs, raises: [].}

--- a/src/playdate/bindings/utils.nim
+++ b/src/playdate/bindings/utils.nim
@@ -1,7 +1,5 @@
 import macros
 
-var realloc*: proc(p: pointer, size: csize_t): pointer {.cdecl.}
-
 func toNimSymbol(typeSymbol: string): string =
     case typeSymbol:
         of "cint":

--- a/src/playdate/types.nim
+++ b/src/playdate/types.nim
@@ -1,4 +1,3 @@
-import bindings/utils
 
 type SDKArrayObj[T] = object
     len: int
@@ -7,7 +6,7 @@ type SDKArray*[T] = ref SDKArrayObj[T]
 
 proc `=destroy`*[T](this: var SDKArrayObj[T]) =
     if this.data != nil:
-        discard utils.realloc(this.data, 0)
+        deallocImpl(this.data)
 
 proc `[]`*[T](this: SDKArray[T]; i: Natural): lent T =
     assert i < this.len


### PR DESCRIPTION
Fixes #59

This change adds a deep integration within Nim for using the playdate memory allocator. This change fixes a host of memory corruption errors that I was experiencing on device only.