### PR TITLE
Reduce heap allocations

### DIFF
--- a/src/playdate/graphics.nim
+++ b/src/playdate/graphics.nim
@@ -363,9 +363,9 @@ proc drawRotated*(this: LCDBitmap, x: int, y: int, rotation: float32, centerX: f
     playdate.graphics.drawRotatedBitmap(this.resource, x.cint, y.cint, rotation.cfloat, centerX.cfloat, centerY.cfloat,
         xScale.cfloat, yScale.cfloat)
 
-proc width*(this: LCDBitmap): int = this.getData.width
+proc width*(this: LCDBitmap): int = this.getSize.width
 
-proc height*(this: LCDBitmap): int = this.getData.height
+proc height*(this: LCDBitmap): int = this.getSize.height
 
 proc setBitmapMask*(
     this: LCDBitmap,

--- a/src/playdate/sprite.nim
+++ b/src/playdate/sprite.nim
@@ -84,10 +84,20 @@ proc remove*(this: LCDSprite) =
     # spritesData.remove(dataNode[])
     playdate.sprite.setUserdata(this.resource, nil)
 
-proc removeSprites*(this: ptr PlaydateSprite, sprites: seq[LCDSprite]) =
+proc removeSprites*(this: ptr PlaydateSprite, sprites: openarray[LCDSprite]) =
     privateAccess(PlaydateSprite)
-    let spritePointers = sprites.map(proc(s: LCDSprite): LCDSpritePtr = return s.resource)
-    this.removeSprites(cast[ptr LCDSpritePtr](unsafeAddr(spritePointers[0])), spritePointers.len.cint)
+
+    var count = 0
+    var spritePointers: array[10, LCDSpritePtr]
+    for sprite in sprites:
+        if count == 10:
+            count = 0
+            this.removeSprites(addr spritePointers[0], count.cint)
+        spritePointers[count] = sprite.resource
+        count += 1
+    if count > 0:
+        this.removeSprites(addr spritePointers[0], count.cint)
+
     for i, s in sprites:
         let dataNode = cast[ptr DoublyLinkedNodeObj[LCDSprite]](this.getUserdata(s.resource))
         if dataNode == nil:


### PR DESCRIPTION
This is a set of changes that reduces the number of heap allocations performed:

* Introduces `BitmapDataObj`, which is a version of `BitmapData` on the stack
* Use `getSize` for `width` and `height`, which puts data on the stack
* Pass an `openarray` into `removeSprites`, which allows arrays to be passed in
* Batch calls within `removeSprites` to use a stack allocated array instead of creating a `seq`