### PR TITLE
FIX debug bitmap should not be free'd

### DIFF
--- a/src/playdate/graphics.nim
+++ b/src/playdate/graphics.nim
@@ -341,7 +341,7 @@ proc set*(view: var BitmapView, x, y: int, color: LCDSolidColor) =
 
 proc getDebugBitmap*(this: ptr PlaydateGraphics): LCDBitmap =
     privateAccess(PlaydateGraphics)
-    return LCDBitmap(resource: this.getDebugBitmap(), free: false)
+    return LCDBitmap(resource: this.getDebugBitmap(), free: false) # do not free: system owns this
 
 proc copyFrameBufferBitmap*(this: ptr PlaydateGraphics): LCDBitmap =
     privateAccess(PlaydateGraphics)

--- a/src/playdate/graphics.nim
+++ b/src/playdate/graphics.nim
@@ -341,7 +341,7 @@ proc set*(view: var BitmapView, x, y: int, color: LCDSolidColor) =
 
 proc getDebugBitmap*(this: ptr PlaydateGraphics): LCDBitmap =
     privateAccess(PlaydateGraphics)
-    return LCDBitmap(resource: this.getDebugBitmap(), free: true) # Who should manage this memory? Not clear. Auto-managed.
+    return LCDBitmap(resource: this.getDebugBitmap(), free: false)
 
 proc copyFrameBufferBitmap*(this: ptr PlaydateGraphics): LCDBitmap =
     privateAccess(PlaydateGraphics)

--- a/tests/t_graphics.nim
+++ b/tests/t_graphics.nim
@@ -51,6 +51,12 @@ proc execGraphicsTests*(runnable: bool) =
                 let img = playdate.graphics.newBitmap(10, 10, kColorWhite)
                 discard playdate.graphics.createPattern(img, 0, 0)
 
+        test "DebugBitmap should not be freed after use":
+            if runnable:
+                discard playdate.graphics.getDebugBitmap()
+                # if the bitmap was freed, this would crash
+                discard playdate.graphics.getDebugBitmap()
+
         test "Bitmaps should be loadable from files":
             if runnable:
                 let img = playdate.graphics.newBitmap("boxes.png")


### PR DESCRIPTION
⚠️ I'm out of my depth here

Please review carefully, but I think this is the way to do it

**Before this change**
Simulator would crash with a nillegal access exception on the **second** invocation of this sample

```
let debugBitmap = gfx.getDebugBitmap()
gfx.pushContext(debugBitmap)
gfx.fillRect(x, y, width, height, kColorWhite)
gfx.popContext()
```

**After this change**
🌞 