### PR TITLE
Don't use refs for unmanaged bitmaps

### DIFF
--- a/playdate_example/src/playdate_example.nim
+++ b/playdate_example/src/playdate_example.nim
@@ -99,8 +99,8 @@ proc handler(event: PDSystemEvent, keycode: uint) {.raises: [].} =
         font = try: playdate.graphics.newFont(FONT_PATH) except: nil
         playdate.graphics.setFont(font)
 
-        playdateNimBitmap = try: playdate.graphics.newBitmap(PLAYDATE_NIM_IMAGE_PATH) except: nil
-        nimLogoBitmap = try: playdate.graphics.newBitmap(NIM_IMAGE_PATH) except: nil
+        playdateNimBitmap = try: playdate.graphics.newBitmap(PLAYDATE_NIM_IMAGE_PATH) except: return
+        nimLogoBitmap = try: playdate.graphics.newBitmap(NIM_IMAGE_PATH) except: return
 
         sprite = playdate.sprite.newSprite()
         sprite.add()

--- a/src/playdate/sprite.nim
+++ b/src/playdate/sprite.nim
@@ -127,7 +127,7 @@ proc bounds*(this: LCDSprite): PDRect =
 proc setImage*(this: LCDSprite, image: LCDBitmap, flip: LCDBitmapFlip) =
     privateAccess(PlaydateSprite)
     privateAccess(LCDBitmap)
-    playdate.sprite.setImage(this.resource, if image != nil: image.resource else: nil, flip)
+    playdate.sprite.setImage(this.resource, image.resource, flip)
     this.bitmap = image
 
 proc getImage*(this: LCDSprite): LCDBitmap =
@@ -404,12 +404,12 @@ proc setStencilPattern*(this: LCDSprite, pattern: array[8, uint8]) =
 proc clearStencil*(this: LCDSprite) =
     privateAccess(PlaydateSprite)
     playdate.sprite.clearStencil(this.resource)
-    this.stencil = nil
+    this.stencil.reset()
 
 proc setStencilImage*(this: LCDSprite, stencil: LCDBitmap, tile: bool) =
     privateAccess(PlaydateSprite)
     privateAccess(LCDBitmap)
-    playdate.sprite.setStencilImage(this.resource, if stencil != nil: stencil.resource else: nil, if tile: 1 else: 0)
+    playdate.sprite.setStencilImage(this.resource, stencil.resource, if tile: 1 else: 0)
     this.stencil = stencil
 
 proc setCenter*(this: LCDSprite, x: float32, y: float32) =


### PR DESCRIPTION
This reduces the number of small memory allocations that happens when working with bitmaps. Bitmaps are split into two categories: managed and unmanaged. Unmanaged bitmaps are passed around by copying pointers, managed bitmaps are passed around using nim object refs.