### PR TITLE
[DRAFT] Scoreboards: Canonical implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,4 +178,3 @@ This project is a work in progress, here's what is missing right now:
 - various playdate.sound funcionalities (but FilePlayer, SamplePlayer and SoundSequence are available)
 - playdate.json, but you can use Nim std/json, which is very convenient
 - advanced playdate.lua features, but basic Lua interop is available
-- playdate.scoreboards, undocumented even in the official C API docs

--- a/src/playdate/api.nim
+++ b/src/playdate/api.nim
@@ -6,8 +6,8 @@ import std/importutils
 import bindings/api
 export api
 
-import graphics, system, file, sprite, display, sound, lua, json, utils, types, nineslice
-export graphics, system, file, sprite, display, sound, lua, json, utils, types, nineslice
+import graphics, system, file, sprite, display, sound, scoreboards, lua, json, utils, types, nineslice
+export graphics, system, file, sprite, display, sound, scoreboards, lua, json, utils, types, nineslice
 
 macro initSDK*() =
     return quote do:

--- a/src/playdate/bindings/api.nim
+++ b/src/playdate/bindings/api.nim
@@ -1,6 +1,6 @@
 {.push raises: [].}
 
-import graphics, system, file, display, sprite, sound, lua
+import graphics, system, file, display, sprite, sound, scoreboards, lua
 
 type PlaydateAPI* {.importc: "PlaydateAPI", header: "pd_api.h".} = object
     system* {.importc: "system".}: ptr PlaydateSys
@@ -9,6 +9,7 @@ type PlaydateAPI* {.importc: "PlaydateAPI", header: "pd_api.h".} = object
     sprite* {.importc: "sprite".}: ptr PlaydateSprite
     display* {.importc: "display".}: ptr PlaydateDisplay
     sound* {.importc: "sound".}: ptr PlaydateSound
+    scoreboards* {.importc: "scoreboards".}: ptr PlaydateScoreboards
     lua* {.importc: "lua".}: ptr PlaydateLua
     # json* {.importc: "json".}: ptr PlaydateJSON # Unavailable, use std/json
 

--- a/src/playdate/bindings/scoreboards.nim
+++ b/src/playdate/bindings/scoreboards.nim
@@ -24,23 +24,26 @@ type PDBoardsList* {.importc: "PDBoardsList", header: "pd_api_scoreboards.h", by
     lastUpdated* {.importc: "lastUpdated".}: uint32
     boards* {.importc: "boards".}: ptr PDBoard
 
-type AddScoreCallback* = proc (score: ptr PDScore; errorMessage: cstring) {.cdecl.}
-type PersonalBestCallback* = proc (score: ptr PDScore; errorMessage: cstring) {.cdecl.}
-type BoardsListCallback* = proc (boards: ptr PDBoardsList; errorMessage: cstring) {.cdecl.}
-type ScoresCallback* = proc (scores: ptr PDScoresList; errorMessage: cstring) {.cdecl.}
+  # todo register free functions
+
+
+type AddScoreCallbackRaw* = proc (score: ptr PDScore; errorMessage: cstring) {.cdecl.}
+type PersonalBestCallbackRaw* = proc (score: ptr PDScore; errorMessage: cstring) {.cdecl.}
+type BoardsListCallbackRaw* = proc (boards: ptr PDBoardsList; errorMessage: cstring) {.cdecl.}
+type ScoresCallbackRaw* = proc (scores: ptr PDScoresList; errorMessage: cstring) {.cdecl.}
 
 sdktype:
     type PlaydateScoreboards* {.importc: "const struct playdate_scoreboards", header: "pd_api.h".} = object
         addScore* {.importc: "addScore".}: proc (boardId: cstring; value: uint32;
-            callback: AddScoreCallback): cint {.cdecl.}
+            callback: AddScoreCallbackRaw): cint {.cdecl.}
         getPersonalBest* {.importc: "getPersonalBest".}: proc (boardId: cstring;
-            callback: PersonalBestCallback): cint {.cdecl.}
+            callback: PersonalBestCallbackRaw): cint {.cdecl.}
         freeScore* {.importc: "freeScore".}: proc (score: ptr PDScore) {.cdecl.}
         getScoreboards* {.importc: "getScoreboards".}: proc (
-            callback: BoardsListCallback): cint {.cdecl.}
+            callback: BoardsListCallbackRaw): cint {.cdecl.}
         freeBoardsList* {.importc: "freeBoardsList".}: proc (
             boardsList: ptr PDBoardsList) {.cdecl.}
         getScores* {.importc: "getScores".}: proc (boardId: cstring;
-            callback: ScoresCallback): cint {.cdecl.}
+            callback: ScoresCallbackRaw): cint {.cdecl.}
         freeScoresList* {.importc: "freeScoresList".}: proc (
             scoresList: ptr PDScoresList) {.cdecl.}

--- a/src/playdate/bindings/scoreboards.nim
+++ b/src/playdate/bindings/scoreboards.nim
@@ -2,48 +2,51 @@
 
 import utils
 
-type PDScore* {.importc: "PDScore", header: "pd_api_scoreboards.h", bycopy.} = object
-    rank* {.importc: "rank".}: uint32
-    value* {.importc: "value".}: uint32
+type PDScoreRaw* {.importc: "PDScore", header: "pd_api.h", bycopy.} = object
+    rank* {.importc: "rank".}: cuint
+    value* {.importc: "value".}: cuint
     player* {.importc: "player".}: cstring
 
-type PDScoresList* {.importc: "PDScoresList", header: "pd_api_scoreboards.h", bycopy.} = object
+type PDScorePtr* = ptr PDScoreRaw
+type PDScore* = ref PDScoreRaw
+
+type PDScoresListRaw* {.importc: "PDScoresList", header: "pd_api.h", bycopy.} = object
     boardID* {.importc: "boardID".}: cstring
     count* {.importc: "count".}: cuint
-    lastUpdated* {.importc: "lastUpdated".}: uint32
+    lastUpdated* {.importc: "lastUpdated".}: cuint
     playerIncluded* {.importc: "playerIncluded".}: cint
     limit* {.importc: "limit".}: cuint
-    scores* {.importc: "scores".}: ptr PDScore
+    scores* {.importc: "scores".}: ptr PDScoreRaw
 
-type PDBoard* {.importc: "PDBoard", header: "pd_api_scoreboards.h", bycopy.} = object
+type PDBoardRaw* {.importc: "PDBoard", header: "pd_api.h", bycopy.} = object
     boardID* {.importc: "boardID".}: cstring
     name* {.importc: "name".}: cstring
 
-type PDBoardsList* {.importc: "PDBoardsList", header: "pd_api_scoreboards.h", bycopy.} = object
+type PDBoardsListRaw* {.importc: "PDBoardsList", header: "pd_api.h", bycopy.} = object
     count* {.importc: "count".}: cuint
-    lastUpdated* {.importc: "lastUpdated".}: uint32
-    boards* {.importc: "boards".}: ptr PDBoard
+    lastUpdated* {.importc: "lastUpdated".}: cuint
+    boards* {.importc: "boards".}: ptr PDBoardRaw
 
   # todo register free functions
 
 
-type AddScoreCallbackRaw* = proc (score: ptr PDScore; errorMessage: cstring) {.cdecl.}
-type PersonalBestCallbackRaw* = proc (score: ptr PDScore; errorMessage: cstring) {.cdecl.}
-type BoardsListCallbackRaw* = proc (boards: ptr PDBoardsList; errorMessage: cstring) {.cdecl.}
-type ScoresCallbackRaw* = proc (scores: ptr PDScoresList; errorMessage: cstring) {.cdecl.}
+type PersonalBestCallbackRaw* {.importc: "PersonalBestCallback", header: "pd_api.h".} = proc (score: PDScorePtr; errorMessage: cstring) {.cdecl.}
+# type AddScoreCallbackRaw* = proc (score: ptr PDScoreRaw; errorMessage: cstring) {.cdecl.}
+# type BoardsListCallbackRaw* = proc (boards: ptr PDBoardsListRaw; errorMessage: cstring) {.cdecl.}
+# type ScoresCallbackRaw* = proc (scores: ptr PDScoresListRaw; errorMessage: cstring) {.cdecl.}
 
 sdktype:
     type PlaydateScoreboards* {.importc: "const struct playdate_scoreboards", header: "pd_api.h".} = object
-        addScore* {.importc: "addScore".}: proc (boardId: cstring; value: uint32;
-            callback: AddScoreCallbackRaw): cint {.cdecl.}
-        getPersonalBest* {.importc: "getPersonalBest".}: proc (boardId: cstring;
-            callback: PersonalBestCallbackRaw): cint {.cdecl.}
-        freeScore* {.importc: "freeScore".}: proc (score: ptr PDScore) {.cdecl.}
-        getScoreboards* {.importc: "getScoreboards".}: proc (
-            callback: BoardsListCallbackRaw): cint {.cdecl.}
-        freeBoardsList* {.importc: "freeBoardsList".}: proc (
-            boardsList: ptr PDBoardsList) {.cdecl.}
-        getScores* {.importc: "getScores".}: proc (boardId: cstring;
-            callback: ScoresCallbackRaw): cint {.cdecl.}
-        freeScoresList* {.importc: "freeScoresList".}: proc (
-            scoresList: ptr PDScoresList) {.cdecl.}
+        getPersonalBestBinding* {.importc: "getPersonalBest".}: proc (boardId: cstring;
+            callback: PersonalBestCallbackRaw): cint {.cdecl, raises: [].}
+        # addScore* {.importc: "addScore".}: proc (boardId: cstring; value: cuint;
+        #     callback: AddScoreCallbackRaw): cint {.cdecl.}
+        # freeScore* {.importc: "freeScore".}: proc (score: ptr PDScore) {.cdecl.}
+        # getScoreboards* {.importc: "getScoreboards".}: proc (
+        #     callback: BoardsListCallbackRaw): cint {.cdecl.}
+        # freeBoardsList* {.importc: "freeBoardsList".}: proc (
+        #     boardsList: ptr PDBoardsList) {.cdecl.}
+        # getScores* {.importc: "getScores".}: proc (boardId: cstring;
+        #     callback: ScoresCallbackRaw): cint {.cdecl.}
+        # freeScoresList* {.importc: "freeScoresList".}: proc (
+        #     scoresList: ptr PDScoresList) {.cdecl.}

--- a/src/playdate/bindings/scoreboards.nim
+++ b/src/playdate/bindings/scoreboards.nim
@@ -13,9 +13,11 @@ type PDScoresListRaw* {.importc: "PDScoresList", header: "pd_api.h", bycopy.} = 
     boardID* {.importc: "boardID".}: cstring
     count* {.importc: "count".}: cuint
     lastUpdated* {.importc: "lastUpdated".}: cuint
-    playerIncluded* {.importc: "playerIncluded".}: cint
+    playerIncluded* {.importc: "playerIncluded".}: cuint
     limit* {.importc: "limit".}: cuint
     scores* {.importc: "scores".}: ptr PDScoreRaw
+
+type PDScoresListPtr* = ptr PDScoresListRaw
 
 type PDBoardRaw* {.importc: "PDBoard", header: "pd_api.h", bycopy.} = object
     boardID* {.importc: "boardID".}: cstring
@@ -29,7 +31,7 @@ type PDBoardsListRaw* {.importc: "PDBoardsList", header: "pd_api.h", bycopy.} = 
 type PersonalBestCallbackRaw* {.importc: "PersonalBestCallback", header: "pd_api.h".} = proc (score: PDScorePtr; errorMessage: cstring) {.cdecl.}
 # type AddScoreCallbackRaw* = proc (score: ptr PDScoreRaw; errorMessage: cstring) {.cdecl.}
 # type BoardsListCallbackRaw* = proc (boards: ptr PDBoardsListRaw; errorMessage: cstring) {.cdecl.}
-# type ScoresCallbackRaw* = proc (scores: ptr PDScoresListRaw; errorMessage: cstring) {.cdecl.}
+type ScoresCallbackRaw* = proc (scores: ptr PDScoresListRaw; errorMessage: cstring) {.cdecl.}
 
 sdktype:
     type PlaydateScoreboards* {.importc: "const struct playdate_scoreboards", header: "pd_api.h".} = object
@@ -42,7 +44,7 @@ sdktype:
         #     callback: BoardsListCallbackRaw): cint {.cdecl.}
         # freeBoardsList* {.importc: "freeBoardsList".}: proc (
         #     boardsList: ptr PDBoardsList) {.cdecl.}
-        # getScores* {.importc: "getScores".}: proc (boardId: cstring;
-        #     callback: ScoresCallbackRaw): cint {.cdecl.}
-        # freeScoresList* {.importc: "freeScoresList".}: proc (
-        #     scoresList: ptr PDScoresList) {.cdecl.}
+        getScoresBinding* {.importc: "getScores".}: proc (boardId: cstring;
+            callback: ScoresCallbackRaw): cint {.cdecl, raises: [].}
+        freeScoresList* {.importc: "freeScoresList".}: proc (
+            scoresList: PDScoresListPtr) {.cdecl, raises: [].}

--- a/src/playdate/bindings/scoreboards.nim
+++ b/src/playdate/bindings/scoreboards.nim
@@ -8,7 +8,6 @@ type PDScoreRaw* {.importc: "PDScore", header: "pd_api.h", bycopy.} = object
     player* {.importc: "player".}: cstring
 
 type PDScorePtr* = ptr PDScoreRaw
-type PDScore* = ref PDScoreRaw
 
 type PDScoresListRaw* {.importc: "PDScoresList", header: "pd_api.h", bycopy.} = object
     boardID* {.importc: "boardID".}: cstring
@@ -27,9 +26,6 @@ type PDBoardsListRaw* {.importc: "PDBoardsList", header: "pd_api.h", bycopy.} = 
     lastUpdated* {.importc: "lastUpdated".}: cuint
     boards* {.importc: "boards".}: ptr PDBoardRaw
 
-  # todo register free functions
-
-
 type PersonalBestCallbackRaw* {.importc: "PersonalBestCallback", header: "pd_api.h".} = proc (score: PDScorePtr; errorMessage: cstring) {.cdecl.}
 # type AddScoreCallbackRaw* = proc (score: ptr PDScoreRaw; errorMessage: cstring) {.cdecl.}
 # type BoardsListCallbackRaw* = proc (boards: ptr PDBoardsListRaw; errorMessage: cstring) {.cdecl.}
@@ -39,9 +35,9 @@ sdktype:
     type PlaydateScoreboards* {.importc: "const struct playdate_scoreboards", header: "pd_api.h".} = object
         getPersonalBestBinding* {.importc: "getPersonalBest".}: proc (boardId: cstring;
             callback: PersonalBestCallbackRaw): cint {.cdecl, raises: [].}
+        freeScore* {.importc: "freeScore".}: proc (score: PDScorePtr) {.cdecl, raises: [].}
         # addScore* {.importc: "addScore".}: proc (boardId: cstring; value: cuint;
         #     callback: AddScoreCallbackRaw): cint {.cdecl.}
-        # freeScore* {.importc: "freeScore".}: proc (score: ptr PDScore) {.cdecl.}
         # getScoreboards* {.importc: "getScoreboards".}: proc (
         #     callback: BoardsListCallbackRaw): cint {.cdecl.}
         # freeBoardsList* {.importc: "freeBoardsList".}: proc (

--- a/src/playdate/scoreboards.nim
+++ b/src/playdate/scoreboards.nim
@@ -1,0 +1,31 @@
+{.push raises: [].}
+
+import std/importutils
+
+import system
+import bindings/[api, types]
+import bindings/scoreboards
+
+# Only export public symbols, then import all
+export scoreboards
+{.hint[DuplicateModuleImport]: off.}
+import bindings/scoreboards {.all.}
+
+type
+  AddScoreCallback* = proc(score: ptr PDScore, errorMessage: string)
+  PersonalBestCallback* = proc(score: ptr PDScore, errorMessage: string)
+  BoardsListCallback* = proc(boards: ptr PDBoardsList, errorMessage: string)
+  ScoresCallback* = proc(scores: ptr PDScoresList, errorMessage: string)
+
+proc addScore*(this: ptr PlaydateScoreboards, boardID: string, value: uint32, callback: AddScoreCallback): int32 =
+  privateAccess(PlaydateScoreboards)
+proc getPersonalBest*(this: ptr PlaydateScoreboards, boardID: string, callback: PersonalBestCallback): int32 =
+  privateAccess(PlaydateScoreboards)
+
+# proc freeScore*(score: ptr PDScore) 
+proc getScoreboards*(this: ptr PlaydateScoreboards, callback: BoardsListCallback): int32 =
+  privateAccess(PlaydateScoreboards)
+# proc freeBoardsList*(boardsList: ptr PDBoardsList) 
+proc getScores*(this: ptr PlaydateScoreboards, boardID: string, callback: ScoresCallback): int32 =
+  privateAccess(PlaydateScoreboards)
+# proc freeScoresList*(scoresList: ptr PDScoresList) 

--- a/src/playdate/scoreboards.nim
+++ b/src/playdate/scoreboards.nim
@@ -11,16 +11,33 @@ export scoreboards
 {.hint[DuplicateModuleImport]: off.}
 import bindings/scoreboards {.all.}
 
+type PDScoreObj {.requiresinit.} = object
+  resource: PDScorePtr
+type PDScore* = ref PDScoreObj
+
 type
   # AddScoreCallback* = proc(score: ptr PDScore, errorMessage: string)
   PersonalBestCallback* = proc(score: PDScore, errorMessage: string)
   # BoardsListCallback* = proc(boards: ptr PDBoardsList, errorMessage: string)
   # ScoresCallback* = proc(scores: ptr PDScoresList, errorMessage: string)
 
+proc value*(this: PDScore): uint32 = this.resource.value
+proc rank*(this: PDScore): uint32 = this.resource.rank
+proc player*(this: PDScore): string = $this.resource.player
+
+
+proc `=destroy`(this: PDSCoreObj) =
+  privateAccess(PlaydateScoreboards)
+  playdate.scoreboards.freeScore(this.resource)
+
 var privatePersonalBestCallback: PersonalBestCallback
 
 proc invokePersonalBestCallback(score: PDScorePtr, errorMessage: ConstChar) {.cdecl, raises: [].} =
-  privatePersonalBestCallback(cast[PDScore](score), $errorMessage)
+  if score == nil and errorMessage == nil:
+    privatePersonalBestCallback(nil, "Playdate-nim: No personal best")
+    return
+    
+  privatePersonalBestCallback(PDscore(resource: score), $errorMessage)
 
 # proc addScore*(this: ptr PlaydateScoreboards, boardID: string, value: uint32, callback: AddScoreCallback): int32 =
 #   privateAccess(PlaydateScoreboards)
@@ -30,10 +47,7 @@ proc getPersonalBest*(this: ptr PlaydateScoreboards, boardID: string, callback: 
   privatePersonalBestCallback = callback
   return this.getPersonalBestBinding(boardID.cstring, invokePersonalBestCallback)
 
-# proc freeScore*(score: ptr PDScore) 
 # proc getScoreboards*(this: ptr PlaydateScoreboards, callback: BoardsListCallback): int32 =
 #   privateAccess(PlaydateScoreboards)
-# # proc freeBoardsList*(boardsList: ptr PDBoardsList) 
 # proc getScores*(this: ptr PlaydateScoreboards, boardID: string, callback: ScoresCallback): int32 =
 #   privateAccess(PlaydateScoreboards)
-# # proc freeScoresList*(scoresList: ptr PDScoresList) 

--- a/src/playdate/scoreboards.nim
+++ b/src/playdate/scoreboards.nim
@@ -2,8 +2,10 @@
 
 import std/importutils
 
-import system
+import std/[importutils, lists, sequtils]
+
 import bindings/[api, types]
+import types {.all.}
 import bindings/scoreboards
 
 # Only export public symbols, then import all
@@ -15,22 +17,45 @@ type PDScoreObj {.requiresinit.} = object
   resource: PDScorePtr
 type PDScore* = ref PDScoreObj
 
+type PDScoresListObj {.requiresinit.} = object
+  resource: PDScoresListPtr
+type PDScoresList* = ref PDScoresListObj
+
 type
   # AddScoreCallback* = proc(score: ptr PDScore, errorMessage: string)
   PersonalBestCallback* = proc(score: PDScore, errorMessage: string)
   # BoardsListCallback* = proc(boards: ptr PDBoardsList, errorMessage: string)
-  # ScoresCallback* = proc(scores: ptr PDScoresList, errorMessage: string)
+  ScoresCallback* = proc(scores: PDScoresList, errorMessage: string)
 
 proc value*(this: PDScore): uint32 = this.resource.value
 proc rank*(this: PDScore): uint32 = this.resource.rank
 proc player*(this: PDScore): string = $this.resource.player
-
-
 proc `=destroy`(this: PDSCoreObj) =
   privateAccess(PlaydateScoreboards)
   playdate.scoreboards.freeScore(this.resource)
 
+proc boardID*(this: PDScoresList): string = $this.resource.boardID
+proc count*(this: PDScoresList): uint32 = this.resource.count
+proc lastUpdated*(this: PDScoresList): uint32 = this.resource.lastUpdated
+proc playerIncluded*(this: PDScoresList): uint32 = this.resource.playerIncluded
+proc limit*(this: PDScoresList): uint32 = this.resource.limit
+proc scores*(this: PDScoresList): seq[PDScore] =
+  privateAccess(SDKArray)
+  let length = this.resource.count.cint
+  let cArray = SDKArray[PDScorePtr](data: cast[ptr UncheckedArray[PDScorePtr]](this.resource.scores), len: length)
+
+  result = newSeq[PDScore](this.resource.count)
+  var i = 0
+  for scr in cArray:
+    result[i] = PDScore(resource: scr)
+    i *= 1
+  
+proc `=destroy`(this: PDScoresListObj) =
+  privateAccess(PlaydateScoreboards)
+  playdate.scoreboards.freeScoresList(this.resource)
+
 var privatePersonalBestCallbacks = newSeq[PersonalBestCallback]()
+var privateGetScoresCallbacks = newSeq[ScoresCallback]()
 
 proc invokePersonalBestCallback(score: PDScorePtr, errorMessage: ConstChar) {.cdecl, raises: [].} =
   let callback = privatePersonalBestCallbacks.pop() # first in, first out
@@ -39,6 +64,14 @@ proc invokePersonalBestCallback(score: PDScorePtr, errorMessage: ConstChar) {.cd
     return
     
   callback(PDscore(resource: score), $errorMessage)
+
+proc invokeScoresCallback(scores: PDScoresListPtr, errorMessage: ConstChar) {.cdecl, raises: [].} =
+  let callback = privateGetScoresCallbacks.pop() # first in, first out
+  if scores == nil and errorMessage == nil:
+    callback(nil, "Playdate-nim: No scores")
+    return
+    
+  callback(PDScoresList(resource: scores), $errorMessage)
 
 # proc addScore*(this: ptr PlaydateScoreboards, boardID: string, value: uint32, callback: AddScoreCallback): int32 =
 #   privateAccess(PlaydateScoreboards)
@@ -50,5 +83,7 @@ proc getPersonalBest*(this: ptr PlaydateScoreboards, boardID: string, callback: 
 
 # proc getScoreboards*(this: ptr PlaydateScoreboards, callback: BoardsListCallback): int32 =
 #   privateAccess(PlaydateScoreboards)
-# proc getScores*(this: ptr PlaydateScoreboards, boardID: string, callback: ScoresCallback): int32 =
-#   privateAccess(PlaydateScoreboards)
+proc getScores*(this: ptr PlaydateScoreboards, boardID: string, callback: ScoresCallback): int32 =
+  privateAccess(PlaydateScoreboards)
+  privateGetScoresCallbacks.insert(callback)
+  return this.getScoresBinding(boardID.cstring, invokeScoresCallback)

--- a/src/playdate/scoreboards.nim
+++ b/src/playdate/scoreboards.nim
@@ -19,7 +19,7 @@ type
 
 var privatePersonalBestCallback: PersonalBestCallback
 
-proc invokePersonalBestCallback(score: PDScorePtr, errorMessage: cstring) {.cdecl, raises: [].} =
+proc invokePersonalBestCallback(score: PDScorePtr, errorMessage: ConstChar) {.cdecl, raises: [].} =
   privatePersonalBestCallback(cast[PDScore](score), $errorMessage)
 
 # proc addScore*(this: ptr PlaydateScoreboards, boardID: string, value: uint32, callback: AddScoreCallback): int32 =

--- a/src/playdate/scoreboards.nim
+++ b/src/playdate/scoreboards.nim
@@ -12,20 +12,28 @@ export scoreboards
 import bindings/scoreboards {.all.}
 
 type
-  AddScoreCallback* = proc(score: ptr PDScore, errorMessage: string)
-  PersonalBestCallback* = proc(score: ptr PDScore, errorMessage: string)
-  BoardsListCallback* = proc(boards: ptr PDBoardsList, errorMessage: string)
-  ScoresCallback* = proc(scores: ptr PDScoresList, errorMessage: string)
+  # AddScoreCallback* = proc(score: ptr PDScore, errorMessage: string)
+  PersonalBestCallback* = proc(score: PDScore, errorMessage: string)
+  # BoardsListCallback* = proc(boards: ptr PDBoardsList, errorMessage: string)
+  # ScoresCallback* = proc(scores: ptr PDScoresList, errorMessage: string)
 
-proc addScore*(this: ptr PlaydateScoreboards, boardID: string, value: uint32, callback: AddScoreCallback): int32 =
-  privateAccess(PlaydateScoreboards)
+var privatePersonalBestCallback: PersonalBestCallback
+
+proc invokePersonalBestCallback(score: PDScorePtr, errorMessage: cstring) {.cdecl, raises: [].} =
+  privatePersonalBestCallback(cast[PDScore](score), $errorMessage)
+
+# proc addScore*(this: ptr PlaydateScoreboards, boardID: string, value: uint32, callback: AddScoreCallback): int32 =
+#   privateAccess(PlaydateScoreboards)
+
 proc getPersonalBest*(this: ptr PlaydateScoreboards, boardID: string, callback: PersonalBestCallback): int32 =
   privateAccess(PlaydateScoreboards)
+  privatePersonalBestCallback = callback
+  return this.getPersonalBestBinding(boardID.cstring, invokePersonalBestCallback)
 
 # proc freeScore*(score: ptr PDScore) 
-proc getScoreboards*(this: ptr PlaydateScoreboards, callback: BoardsListCallback): int32 =
-  privateAccess(PlaydateScoreboards)
-# proc freeBoardsList*(boardsList: ptr PDBoardsList) 
-proc getScores*(this: ptr PlaydateScoreboards, boardID: string, callback: ScoresCallback): int32 =
-  privateAccess(PlaydateScoreboards)
-# proc freeScoresList*(scoresList: ptr PDScoresList) 
+# proc getScoreboards*(this: ptr PlaydateScoreboards, callback: BoardsListCallback): int32 =
+#   privateAccess(PlaydateScoreboards)
+# # proc freeBoardsList*(boardsList: ptr PDBoardsList) 
+# proc getScores*(this: ptr PlaydateScoreboards, boardID: string, callback: ScoresCallback): int32 =
+#   privateAccess(PlaydateScoreboards)
+# # proc freeScoresList*(scoresList: ptr PDScoresList) 


### PR DESCRIPTION
An alternative to https://github.com/samdze/playdate-nim/pull/82.

In #82 the data returned from the playdate API is mapped to plain Nim objects, after which the C struct is free'd immediately.

The approach in this PR is more in line with the other APIs that we already offer. It wraps the c-struct and registers a destroy function to free it when the wrapper goes out of scope.
The procs for value, rank and player are unsafe to use. Users should first check whether score is nil before use.

I'm in favor of abandoning this one and continuing with #82, but I'm open to completing this one if both @Nycto and @samdze prefer it