### PR TITLE
ADD PDResultSuccessEmpty

### DIFF
--- a/src/playdate/scoreboards.nim
+++ b/src/playdate/scoreboards.nim
@@ -61,7 +61,10 @@ template invokeCallback(callbackSeqs, value, errorMessage, freeValue, builder: u
     type ResultType = typeof(builder)
     let callback = callbackSeqs.pop()
     if value == nil:
-        callback(PDResult[ResultType](kind: PDResultUnavailable))
+        if errorMessage == nil:
+            callback(PDResult[ResultType](kind: PDResultUnavailable))
+        else:
+            callback(PDResult[ResultType](kind: PDResultError, message: $errorMessage))
     else:
         try:
             let built = builder

--- a/src/playdate/scoreboards.nim
+++ b/src/playdate/scoreboards.nim
@@ -31,11 +31,16 @@ type
         lastUpdated*: uint32
         boards*: seq[PDBoard]
 
-    PDResultKind* = enum PDResultSuccess, PDResultError
+    PDResultKind* = enum 
+      PDResultSuccess, 
+      PDResultSuccessEmpty
+        ## The operation completed successfully, but the response had no data
+      PDResultError, 
 
     PDResult*[T] = object
         case kind*: PDResultKind
         of PDResultSuccess: result*: T
+        of PDResultSuccessEmpty: discard
         of PDResultError: message*: string
 
     PersonalBestCallback* = proc(result: PDResult[PDScore]) {.raises: [].}
@@ -56,8 +61,7 @@ template invokeCallback(callbackSeqs, value, errorMessage, freeValue, builder: u
     type ResultType = typeof(builder)
     let callback = callbackSeqs.pop()
     if value == nil:
-        let message = if errorMessage == nil: "Playdate-nim: No value provided for callback" else: $errorMessage
-        callback(PDResult[ResultType](kind: PDResultError, message: message))
+        callback(PDResult[ResultType](kind: PDResultSuccessEmpty))
     else:
         try:
             let built = builder
@@ -88,11 +92,13 @@ proc invokeBoardsListCallback(boardsList: PDBoardsListPtr, errorMessage: ConstCh
         PDBoardsList(lastUpdated: boardsList.lastUpdated, boards: boardsSeq)
 
 proc getPersonalBest*(this: ptr PlaydateScoreboards, boardID: string, callback: PersonalBestCallback): int32 {.discardable.} =
+    ## Responds with PDResultSuccessEmpty if no score exists for the current player.
     privateAccess(PlaydateScoreboards)
     privatePersonalBestCallbacks.insert(callback) # by inserting the callback at the start, it will be popped last: first in, first out
     return this.getPersonalBestBinding(boardID.cstring, invokePersonalBestCallback)
 
 proc addScore*(this: ptr PlaydateScoreboards, boardID: string, value: uint32, callback: AddScoreCallback): int32 {.discardable.} =
+    ## Responds with PDResultSuccessEmpty if the score was qeued for later submission. Probably, Wi-Fi is not available.
     privateAccess(PlaydateScoreboards)
     privateAddScoreCallbacks.insert(callback) # by inserting the callback at the start, it will be popped last: first in, first out
     return this.addScoreBinding(boardID.cstring, value.cuint, invokeAddScoreCallback)

--- a/tests/t_scoreboards.nim
+++ b/tests/t_scoreboards.nim
@@ -11,7 +11,7 @@ proc execScoreboardTests*() =
                 case score.kind
                 of PDResultSuccess: echo $score.result
                 of PDResultError: echo $score.message
-                of PDResultSuccessEmpty: echo "SuccessEmpty"
+                of PDResultUnavailable: echo "SuccessEmpty"
 
         test "addScore":
             playdate.scoreboards.addScore("some_board", 123) do (score: PDResult[PDScore]) -> void:

--- a/tests/t_scoreboards.nim
+++ b/tests/t_scoreboards.nim
@@ -11,7 +11,7 @@ proc execScoreboardTests*() =
                 case score.kind
                 of PDResultSuccess: echo $score.result
                 of PDResultError: echo $score.message
-                of PDResultUnavailable: echo "SuccessEmpty"
+                of PDResultUnavailable: echo "PDResultUnavailable"
 
         test "addScore":
             playdate.scoreboards.addScore("some_board", 123) do (score: PDResult[PDScore]) -> void:

--- a/tests/t_scoreboards.nim
+++ b/tests/t_scoreboards.nim
@@ -11,6 +11,7 @@ proc execScoreboardTests*() =
                 case score.kind
                 of PDResultSuccess: echo $score.result
                 of PDResultError: echo $score.message
+                of PDResultSuccessEmpty: echo "SuccessEmpty"
 
         test "addScore":
             playdate.scoreboards.addScore("some_board", 123) do (score: PDResult[PDScore]) -> void:


### PR DESCRIPTION
By using the Scoreboards API for Wheelsprung, it feels wrong to classify a result without data as an error.

Therefore I added an extra PDResultKind for this and documented the cases where this may be returned to the callback