### PR TITLE
ADD flag to use the host os std lib for compilation

### DIFF
--- a/src/playdate/build/config.nim
+++ b/src/playdate/build/config.nim
@@ -14,6 +14,10 @@ const headlessTesting = defined(simulator) and declared(test)
 const nimbleTesting = not defined(simulator) and not defined(device) and declared(test)
 const testing = headlessTesting or nimbleTesting
 
+# Use the host OS for compilation. This is useful when running supporting development tools that import the playdate SDK or where the os module needs to be available.
+# This does not make the playdate api callable, only the types (header files) are available.
+const useHostOS = defined(useHostOS)
+
 # Path to the playdate src directory when checked out locally
 const localPlaydatePath = currentSourcePath / "../../../../src"
 
@@ -45,7 +49,9 @@ switch("passC", "-Wno-unknown-pragmas")
 switch("passC", "-Wdouble-promotion")
 switch("passC", "-I" & sdkPath() / "C_API")
 
-switch("os", "any")
+if not useHostOS:
+    echo "Setting os to any"
+    switch("os", "any")
 switch("define", "useMalloc")
 switch("define", "standalone")
 switch("threads", "off")
@@ -133,8 +139,8 @@ when defined(simulator):
     switch("passC", "-DTARGET_SIMULATOR=1")
     switch("passC", "-Wstrict-prototypes")
 
-if nimbleTesting:
-    # Compiling for tests.
+if useHostOS or nimbleTesting:
+    # Compiling for host system environment.
     switch("define", "simulator")
     switch("nimcache", nimcacheDir() / "simulator")
     

--- a/src/playdate/build/config.nim
+++ b/src/playdate/build/config.nim
@@ -28,7 +28,7 @@ let nimblePlaydatePath =
     else:
         gorgeEx("nimble path playdate").output.split("\n")[0]
 
-if not testing:
+if not testing and not useHostOS:
     switch("noMain", "on")
 switch("backend", "c")
 switch("mm", "arc")

--- a/src/playdate/build/config.nim
+++ b/src/playdate/build/config.nim
@@ -11,7 +11,7 @@ when not compiles(task):
     import system/nimscript
 
 const headlessTesting = defined(simulator) and declared(test)
-const nimbleTesting = not defined(simulator) and not defined(devide) and declared(test)
+const nimbleTesting = not defined(simulator) and not defined(device) and declared(test)
 const testing = headlessTesting or nimbleTesting
 
 # Path to the playdate src directory when checked out locally


### PR DESCRIPTION
The exact logic / implementation is up for debate, but the intention here is to allow supporting tools such as preprocessors to be run with the full std lib and playdate headers available.

My usecase: a Nim program that uses my game's internal data structures to find and hash level files, and then compares the hashes against a meta data object that is also part of my game code. When there is a hash mismatch, the os module is used to update the files in my machine's source folder with the new hashes.
Having the playdate header files available is convenient, because they are imported by my game code. Using my game code from the hashing updater program would not be possible without pd_api.h being available

See https://github.com/ninovanhooff/wheelsprung/tree/main/scripts/level_hash_updater 