### PR TITLE
ADD getRefreshRate

### DIFF
--- a/src/playdate/bindings/display.nim
+++ b/src/playdate/bindings/display.nim
@@ -4,11 +4,14 @@ import utils
 
 sdktype:
     type PlaydateDisplay* {.importc: "const struct playdate_display", header: "pd_api.h".} = object
+        # directly mapped to C api
         getWidth {.importsdk.}: proc (): cint
         getHeight {.importsdk.}: proc (): cint
-        setRefreshRate {.importsdk.}: proc (rate: cfloat)
-        setInverted {.importc: "setInverted".}: proc (flag: cint) {.cdecl, raises: [].}
         setScale {.importsdk.}: proc (s: cuint)
         setMosaic {.importsdk.}: proc (x: cuint; y: cuint)
+        setOffset* {.importsdk.}: proc (x: cint; y: cint)
+
+        # Called from Nim (src/playdate/display.nim)
+        setRefreshRate {.importc: "setRefreshRate".}: proc (rate: cfloat) {.cdecl, raises: [].}
+        setInverted {.importc: "setInverted".}: proc (flag: cint) {.cdecl, raises: [].}
         setFlipped {.importc: "setFlipped".}: proc (x: cint; y: cint) {.cdecl, raises: [].}
-        setOffset {.importsdk.}: proc (x: cint; y: cint)

--- a/src/playdate/display.nim
+++ b/src/playdate/display.nim
@@ -9,6 +9,11 @@ export display
 {.hint[DuplicateModuleImport]: off.}
 import bindings/display {.all.}
 
+var 
+    refreshRate = 30f
+        ## bookkeeping variable for refresh rate, because API does not provide a getter.
+        ## Initial value is the rate that is set on device boot
+
 proc setInverted* (this: ptr PlaydateDisplay, inverted: bool) =
     privateAccess(PlaydateDisplay)
     this.setInverted(if inverted: 1 else: 0)
@@ -16,3 +21,12 @@ proc setInverted* (this: ptr PlaydateDisplay, inverted: bool) =
 proc setFlipped* (this: ptr PlaydateDisplay, x: bool, y: bool) =
     privateAccess(PlaydateDisplay)
     this.setFlipped(if x: 1 else: 0, if y: 1 else: 0)
+
+
+proc getRefreshRate* (this: ptr PlaydateDisplay): float32 =
+    refreshRate
+
+proc setRefreshRate* (this: ptr PlaydateDisplay, rate: float32) =
+    privateAccess(PlaydateDisplay)
+    refreshRate = rate
+    this.setRefreshRate(rate)


### PR DESCRIPTION
Until implemented in C:

https://devforum.play.date/t/getrefreshrate-in-c/20746

I think the api is straitforward enough to assume the if it gets added to C eventually, it'll have the same signature and we can transparently remove this stopgap local bookkeeping solution. API also matches the lua api

The big advantage of implementing this in playdate-nim rather thhan game code is that this way it is guaranteed that the value is in sync with the actual refreshrate, since there is only 1 possible codepath. ie. it is not possible to call setRefreshRate this way without also updating the variable