### PR TITLE
Update version to 0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ You can also build for simulator and launch it in one command:
 pdn simulate
 ```
 
+Note that the `pdn` command attempts to configure your environment as needed to
+complete the build. This includes creating a `pdxinfo` file automatically, updating your
+`config.nims`, and adding entries to your `.gitignore`. If you don't want this behavior, you
+can add the `--no-auto-config` flag, which will disable this.
+
+## Examples
+
 The example project `playdate_example` also contains VSCode launch configurations to build, start and debug your Nim application from the editor.
 
 Each project contains a `config.nims` file that can be edited to customize how the project should be built, e.g. adding libraries or other external code.

--- a/playdate.nimble
+++ b/playdate.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.21.0"
+version       = "0.22.0"
 author        = "Samuele Zolfanelli"
 description   = "Playdate Nim bindings with extra features."
 license       = "MIT"


### PR DESCRIPTION
Step 1 in a release -- updating version to 0.22.0.

### Release Notes

- Implemented `pdn` build command  as a replacement for direct nimble integration (#98)
- Autogenerate pdxinfo files during builds
- Removed `configure` build command in favor of automatic updates during builds
- Added `getRefreshRate` function
- Don't use refs for unmanaged bitmaps
- Fixed unfindable entries in sparsemap
- Fixed memory tracer reporting calls to deallocate unmanaged memory
- Completely elided memory tracing when disabled
- Reorganized code
