### PR TITLE
Allow pdxinfo custom configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ complete the build. This includes creating a `pdxinfo` file automatically, updat
 `config.nims`, and adding entries to your `.gitignore`. If you don't want this behavior, you
 can add the `--no-auto-config` flag, which will disable this.
 
+### Custom pdxinfo values
+
+Running `pdn` will automatically generate a `pdxinfo` file based on the project
+details in your packages `nimble` file. If you need to customize these values, you can
+add a `pdxinfo` file to the root of your package.
+
 ## Examples
 
 The example project `playdate_example` also contains VSCode launch configurations to build, start and debug your Nim application from the editor.

--- a/src/pdn.nim
+++ b/src/pdn.nim
@@ -1,5 +1,5 @@
 import std/[parseopt, strutils, os, macros, options]
-import playdate/build/[utils, actions]
+import playdate/build/[utils, actions, nimbledump]
 
 type
     BuildCommand = enum simulate, simulator, device, clean, bundle

--- a/src/playdate/build/nimbledump.nim
+++ b/src/playdate/build/nimbledump.nim
@@ -1,0 +1,14 @@
+import std/[strutils, strformat, osproc, json, jsonutils], utils
+
+type
+    NimbleDump* = ref object
+        ## The data pulled from running `nimble dump --json`
+        name*, version*, nimblePath*, author*, desc*, license*: string
+
+proc getNimbleDump*(): NimbleDump =
+    ## Executes nimble with the given set of arguments
+    let (output, exitCode) = execCmdEx("nimble dump --json")
+    if exitCode != 0:
+        echo output
+        raise BuildFail.newException(fmt"Unable to extract nimble dump for package")
+    return parseJson(output).jsonTo(NimbleDump, Joptions(allowExtraKeys: true))

--- a/src/playdate/build/pdxinfo.nim
+++ b/src/playdate/build/pdxinfo.nim
@@ -1,0 +1,55 @@
+import std/[os, parsecfg, streams, strutils, strformat, times, osproc], nimbledump
+
+type PdxInfo* = object
+    ## Details used to populate the pdxinfo file
+    name*, author*, description*, bundleId*, imagePath*, version*, buildNumber*: string
+
+proc `$`*(pdx: PdxInfo): string =
+    for key, value in pdx.fieldPairs:
+        if value != "":
+            result &= key & "=" & value & "\n"
+
+proc write*(pdx: PdxInfo) =
+    ## Writes the pdxinfo file
+    createDir("source")
+    writeFile("source" / "pdxinfo", $pdx)
+
+proc join*(a, b: PdxInfo): PdxInfo =
+    ## Combins two PdxInfo instances
+    result = a
+    for current, override in fields(result, b):
+        if override != "":
+            current = override
+
+proc parsePdx*(data: Stream, filename: string): PdxInfo =
+    ## Parses a pdx config from a string
+    let dict = loadConfig(data, filename)
+    for key, value in result.fieldPairs:
+        value = dict.getSectionValue("", key)
+
+proc readPdx*(path: string): PdxInfo =
+    ## Creates a pdx by reading a local pxinfo file
+    if fileExists(path):
+        return parsePdx(newFileStream(path), path)
+
+proc gitHashOrElse(fallback: string): string =
+    let (output, exitCode) = execCmdEx("git rev-parse HEAD")
+    return if exitCode == 0: output[0..<8] else: fallback
+
+proc toPdxInfo*(
+    dump: NimbleDump,
+    version: string = gitHashOrElse(dump.version),
+    buildNumber: string = now().format("yyyyMMddhhmmss")
+): PdxInfo =
+    ## Creates a base PdxInfo file
+    result.name  = dump.name
+    result.author = dump.author
+    result.description = dump.desc
+
+    let bundleIdPkg = dump.author.toLower().replace(" ", "").replace("-", "").replace("_", "")
+    let bundleIdName = dump.name.replace(" ", "").toLowerAscii()
+    result.bundleId = fmt"com.{bundleIdPkg}.{bundleIdName}"
+    result.imagePath = "launcher"
+    result.version = version
+    result.buildNumber = buildNumber
+

--- a/tests/t_pdxinfo.nim
+++ b/tests/t_pdxinfo.nim
@@ -1,0 +1,69 @@
+import std/[unittest, strutils, streams], playdate/build/[pdxinfo, nimbledump]
+
+suite "Pdxinfo generation":
+
+    test "Produce a default pdxinfo from a nimble dump":
+        let dump = NimbleDump(
+            name: "Lorem Ipsum",
+            version: "0.0.0",
+            nimblePath: "/path/to/nimble",
+            author: "Twas Brillig",
+            desc: "A thing",
+            license: "MIT",
+        )
+
+        check($dump.toPdxInfo("1.2.3", "20250216") == """
+            name=Lorem Ipsum
+            author=Twas Brillig
+            description=A thing
+            bundleId=com.twasbrillig.loremipsum
+            imagePath=launcher
+            version=1.2.3
+            buildNumber=20250216
+            """.dedent())
+
+    test "Read a PDXInfo from a stream":
+        let pdx = newStringStream("""
+            name=Lorem Ipsum
+            author=Twas Brillig
+            description=A thing
+            bundleId=com.twasbrillig.loremipsum
+            imagePath=launcher
+            version=1.2.3
+            buildNumber=20250216
+            """).parsePdx("[stream]")
+
+        check($pdx == """
+            name=Lorem Ipsum
+            author=Twas Brillig
+            description=A thing
+            bundleId=com.twasbrillig.loremipsum
+            imagePath=launcher
+            version=1.2.3
+            buildNumber=20250216
+            """.dedent())
+
+    test "Join together multiple pdxinfo objects":
+        let pdx1 = PdxInfo(
+            name: "Lorem Ipsum",
+            description: "A thing",
+            imagePath: "launcher",
+            version: "1.2.3",
+            buildNumber: "20250216",
+        )
+
+        let pdx2 = PdxInfo(
+            author: "Twas Brillig",
+            bundleId: "com.twasbrillig.loremipsum",
+            version: "3.4.5",
+        )
+
+        check($join(pdx1, pdx2) == """
+            name=Lorem Ipsum
+            author=Twas Brillig
+            description=A thing
+            bundleId=com.twasbrillig.loremipsum
+            imagePath=launcher
+            version=3.4.5
+            buildNumber=20250216
+            """.dedent())


### PR DESCRIPTION
Adds support for dropping a `pdxinfo` file in the root of a project that can override the auto-generated values. This also adds tests for generating the `pdxinfo` file themselves