### PR TITLE
Updates `pdn` to use `argparse` for parsing CLI options

### DIFF
--- a/playdate.nimble
+++ b/playdate.nimble
@@ -11,3 +11,4 @@ bin           = @["pdn"]
 # Dependencies
 
 requires "nim >= 2.0.0"
+requires "argparse 4.0.2"

--- a/src/pdn.nim
+++ b/src/pdn.nim
@@ -8,7 +8,7 @@ type
     CliConfig = object
         ## Configurations collected from the Cli
         command: BuildCommand
-        noAutoConfig: bool
+        noAutoConfig, showVersion: bool
         sdkPath: Option[string]
         extraArgs: seq[string]
 
@@ -29,11 +29,18 @@ proc getCliConfig(): CliConfig =
             case key
             of "sdk-path": result.sdkPath = some(val)
             of "no-auto-config": result.noAutoConfig = true
+            of "v", "version": result.showVersion = true
             else: addExtraArg()
         of cmdEnd:
             discard
 
 let build = getCliConfig()
+
+if build.showVersion:
+    const NimblePkgVersion {.strdefine.} = ""
+    const hash = staticExec("git rev-parse --short HEAD")
+    echo "Playdate nim version ", NimblePkgVersion, " ", hash
+    quit(QuitSuccess)
 
 let dump = getNimbleDump()
 

--- a/src/pdn.nim
+++ b/src/pdn.nim
@@ -1,73 +1,69 @@
-import std/[parseopt, strutils, os, macros, options]
+import std/[os, macros, tables], argparse
 import playdate/build/[utils, actions, nimbledump]
 
-type
-    BuildCommand = enum simulate, simulator, device, clean, bundle
-        ## The various actions that can be executed by this script
-
-    CliConfig = object
-        ## Configurations collected from the Cli
-        command: BuildCommand
-        noAutoConfig, showVersion: bool
-        sdkPath: Option[string]
-        extraArgs: seq[string]
-
-proc getCliConfig(): CliConfig =
-    ## Parses the build configuration from the input options
-    for kind, key, val in getopt():
-        template addExtraArg() =
-            var command = if kind == cmdLongOption: "--" else: "-"
-            command &= key
-            if val != "":
-                command &= ":" & val
-            result.extraArgs.add(command)
-
-        case kind
-        of cmdArgument:
-            result.command = parseEnum[BuildCommand](key)
-        of cmdLongOption, cmdShortOption:
-            case key
-            of "sdk-path": result.sdkPath = some(val)
-            of "no-auto-config": result.noAutoConfig = true
-            of "v", "version": result.showVersion = true
-            else: addExtraArg()
-        of cmdEnd:
-            discard
-
-let build = getCliConfig()
-
-if build.showVersion:
-    const NimblePkgVersion {.strdefine.} = ""
-    const hash = staticExec("git rev-parse --short HEAD")
-    echo "Playdate nim version ", NimblePkgVersion, " ", hash
-    quit(QuitSuccess)
+template read(options, key: untyped; typ: typedesc): auto =
+    ## Reads a CLI flag or option. Checks the current subcommand, if available, then checks the parent
+    (proc: typ =
+        # We use an anonymous proc here because it makes the `when` and `if` expressions inside less complex
+        when compiles(options.key):
+            if options.key != default(typ):
+                return options.key
+        when compiles(options.parentOpts.key):
+            if options.parentOpts.key != default(typ):
+                return options.parentOpts.key
+        return default(typ)
+    )()
 
 let dump = getNimbleDump()
 
-let conf = PlaydateConf(
-    dump: dump,
-    kind: if build.command == device: DeviceBuild else: SimulatorBuild,
-    sdkPath: sdkPath(build.sdkPath),
-    pdxName: dump.name & ".pdx",
-    nimbleArgs: build.extraArgs,
-    noAutoConfig: build.noAutoConfig
-)
+proc parseConf(kind: BuildKind, options: auto): PlaydateConf =
+    # Builds a `PlaydateConf` from the parsed CLI options
+    return PlaydateConf(
+        dump: dump,
+        kind: kind,
+        sdkPath: sdkPath(options.read(sdkPath, string)),
+        pdxName: dump.name & ".pdx",
+        nimbleArgs: options.read(others, seq[string]),
+        noAutoConfig: options.read(noAutoConfig, bool)
+    )
 
-case build.command
-of device, simulate, simulator:
-    conf.configureBuild()
-of clean, bundle:
-    discard
+proc sharedOptions() =
+    ## Adds CLI options shared across multiple kinds of builds
+    option("--sdk-path", help = "Specifies the location of the Playdate SDK")
+    flag("--no-auto-config", help = "Disables editing of config.nims, pdxinfo and .gitignore")
 
-case build.command
-of simulator:
-    conf.simulatorBuild()
-of simulate:
-    conf.simulatorBuild()
-    conf.runSimulator()
-of device:
-    conf.deviceBuild()
-of clean:
-    conf.runClean()
-of bundle:
-    conf.bundlePDX()
+template defineBuild(name: string, kind: BuildKind, action: untyped, helpMessage: string) =
+    ## Defines a subcommand that performs a build
+    command(name):
+        help(helpMessage)
+        sharedOptions()
+        arg("others", nargs = -1, help = "Extra args are passed to nimble")
+        run:
+            action(parseConf(kind, opts))
+
+proc showVersion() =
+    ## Prints the version number of this script
+    const NimblePkgVersion {.strdefine.} = ""
+    const hash = staticExec("git rev-parse --short HEAD")
+    echo "Playdate nim version ", NimblePkgVersion, " ", hash
+
+var p = newParser:
+    help("Nim/Playdate build system")
+    flag("-v", "--version", help = "Show pdn version")
+    sharedOptions()
+    run:
+        if opts.version:
+            showVersion()
+        elif opts.argparse_command == "":
+            runSimulator(parseConf(SimulatorBuild, opts))
+
+    defineBuild("simulator", SimulatorBuild, simulatorBuild, "Execute a build for the simulator")
+    defineBuild("simulate", SimulatorBuild, runSimulator, "Execute a build and run the simulator")
+    defineBuild("device", DeviceBuild, deviceBuild, "Execute a build for device")
+    defineBuild("clean", SimulatorBuild, runClean, "Removes build artifacts")
+    defineBuild("bundle", SimulatorBuild, bundlePDX, "Executes the bundling step without rebuilding the whole project")
+
+try:
+    p.run()
+except UsageError as e:
+    quit(e.msg, 1)

--- a/src/pdn.nim
+++ b/src/pdn.nim
@@ -61,7 +61,7 @@ var p = newParser:
     defineBuild("simulate", SimulatorBuild, runSimulator, "Execute a build and run the simulator")
     defineBuild("device", DeviceBuild, deviceBuild, "Execute a build for device")
     defineBuild("clean", SimulatorBuild, runClean, "Removes build artifacts")
-    defineBuild("bundle", SimulatorBuild, bundlePDX, "Executes the bundling step without rebuilding the whole project")
+    defineBuild("bundle", SimulatorBuild, bundlePDX, "Runs the Playdate compiler (pdc) and creates a pdx.zip")
 
 try:
     p.run()

--- a/src/pdn.nim
+++ b/src/pdn.nim
@@ -14,10 +14,9 @@ template read(options, key: untyped; typ: typedesc): auto =
         return default(typ)
     )()
 
-let dump = getNimbleDump()
-
 proc parseConf(kind: BuildKind, options: auto): PlaydateConf =
     # Builds a `PlaydateConf` from the parsed CLI options
+    let dump = getNimbleDump()
     return PlaydateConf(
         dump: dump,
         kind: kind,

--- a/src/playdate/build/actions.nim
+++ b/src/playdate/build/actions.nim
@@ -94,7 +94,7 @@ proc bundlePDX*(conf: PlaydateConf) =
 proc mv(source, target: string) =
     echo fmt"Moving {source} to {target}"
     if not source.fileExists and not source.dirExists:
-        raise BuildFail.newException(fmt"Expecting the '{source}' to exist, but it doesn't")
+        raise BuildFail.newException(fmt"Expecting the file '{source}' to exist, but it doesn't")
     moveFile(source, target)
 
 proc rm(target: string) =
@@ -125,6 +125,8 @@ proc simulatorBuild*(conf: PlaydateConf) =
 
 proc runSimulator*(conf: PlaydateConf) =
     ## Executes the simulator
+    simulatorBuild(conf)
+
     if not conf.pdxName.dirExists:
         raise BuildFail.newException(fmt"PDX does not exist: {conf.pdxName.absolutePath}")
 

--- a/src/playdate/build/utils.nim
+++ b/src/playdate/build/utils.nim
@@ -1,4 +1,4 @@
-import std/[os, options]
+import std/os
 
 type
     BuildFail* = object of Defect
@@ -12,12 +12,12 @@ const SDK_ENV_VAR* = "PLAYDATE_SDK_PATH"
 
 const playdateSdkPath {.strDefine.} = ""
 
-proc sdkPath*(inputParam: Option[string] = none(string)): string =
+proc sdkPath*(inputParam: string = ""): string =
     ## Returns the path of the playdate SDK
     let sdkPathCache = getConfigDir() / "playdate-nim" / SDK_ENV_VAR
 
-    if inputParam.isSome:
-        result = inputParam.get
+    if inputParam != "":
+        result = inputParam
     elif playdateSdkPath != "":
         result = playdateSdkPath
     elif getEnv(SDK_ENV_VAR) != "":


### PR DESCRIPTION
Details on `argparse` can be found here:

https://www.iffycan.com/nim-argparse/argparse.html

This gives us a more structured CLI parsing mechanism, but also allows for an auto-generated help message:

```
> ./pdn -h
Nim/Playdate build system

Usage:
   [options] COMMAND

Commands:

  simulator        Execute a build for the simulator
  simulate         Execute a build and run the simulator
  device           Execute a build for device
  clean            Removes build artifacts
  bundle           Executes the bundling step without rebuilding the whole project

Options:
  -h, --help
  -v, --version              Show pdn version
  --sdk-path=SDK_PATH        Specifies the location of the Playdate SDK
  --no-auto-config           Disables editing of config.nims, pdxinfo and .gitignore
```