### PR TITLE
Support setSerialMessageCallback

### DIFF
--- a/playdate_example/src/playdate_example.nim
+++ b/playdate_example/src/playdate_example.nim
@@ -150,6 +150,10 @@ proc handler(event: PDSystemEvent, keycode: uint) {.raises: [].} =
             playdate.system.logToConsole("This below is an expected error:")
             playdate.system.logToConsole(getCurrentExceptionMsg())
 
+        # Log any serial messages we receive
+        playdate.system.setSerialMessageCallback do (msg: string) -> void:
+            playdate.system.logToConsole(fmt"Serial message: {msg}")
+
         # Set the update callback
         playdate.system.setUpdateCallback(update)
 

--- a/src/playdate/bindings/system.nim
+++ b/src/playdate/bindings/system.nim
@@ -31,6 +31,8 @@ type PDCallbackFunctionRaw {.importc: "PDCallbackFunction", header: "pd_api.h".}
 
 type PDMenuItemCallbackFunctionRaw {.importc: "PDMenuItemCallbackFunction", header: "pd_api.h".} = proc(userdata: pointer) {.cdecl.}
 
+type PDSerialMessageCallback = proc(msg: ConstChar) {.cdecl.}
+
 # System
 sdktype:
     type PlaydateSys* {.importc: "const struct playdate_sys", header: "pd_api.h".} = object
@@ -90,3 +92,6 @@ sdktype:
         resetElapsedTime* {.importc: "resetElapsedTime".}: proc () {.cdecl, raises: [].} ##  1.4
         getBatteryPercentage {.importsdk.}: proc (): cfloat
         getBatteryVoltage {.importsdk.}: proc (): cfloat
+
+        setSerialMessageCallback {.importc: "setSerialMessageCallback".}:
+            proc(callback: PDSerialMessageCallback) {.cdecl, raises: [].}

--- a/src/playdate/system.nim
+++ b/src/playdate/system.nim
@@ -198,6 +198,14 @@ proc getReduceFlashing* (this: ptr PlaydateSys): bool =
     privateAccess(PlaydateSys)
     return this.getReduceFlashing() == 1
 
+var serialMsgCallback: proc(msg: string)
+
+proc privateSerialMessageCallback(msg: ConstChar) {.cdecl, raises: [].} = serialMsgCallback($msg)
+
+proc setSerialMessageCallback*(this: ptr PlaydateSys, callback: proc(msg: string)) =
+    privateAccess(PlaydateSys)
+    serialMsgCallback = callback
+    this.setSerialMessageCallback(privateSerialMessageCallback)
 
 import std/random
 


### PR DESCRIPTION
Adds support for the `playdate.system.setSerialMessageCallback` function, as documented here:

https://sdk.play.date/2.6.2/Inside%20Playdate%20with%20C.html#f-system.setSerialMessageCallback