### PR TITLE
ADD error catching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: ./.github/actions/build-setup
       with:
         nim-version: ${{ matrix.nim-version }}
-    - run: nimble test
+    - run: nimble test --warning[BareExcept]:off
 
   headless-tests:
     runs-on: ubuntu-latest

--- a/playdate_example/src/playdate_example.nim
+++ b/playdate_example/src/playdate_example.nim
@@ -37,6 +37,16 @@ proc update(): int =
     if kButtonA in buttonState.pushed:
         samplePlayer.play(1, 1.0)
 
+    if kButtonB in buttonState.pushed:
+        let testErrorProc = proc(): int =
+                # intentional division by 0 error
+                return 1 div 0
+        discard runCatchingTyped(
+            fun = testErrorProc,
+            fatal = false,
+            messagePrefix = "Intentional Error: "
+        )
+
     let goalX = x.toFloat
     let goalY = y.toFloat
     let res = sprite.moveWithCollisions(goalX, goalY)

--- a/playdate_example/src/playdate_example.nim
+++ b/playdate_example/src/playdate_example.nim
@@ -39,11 +39,11 @@ proc update(): int =
 
     if kButtonB in buttonState.pushed:
         let testErrorProc = proc(): int =
-                # intentional division by 0 error to showcase error catching behavior
-                # use fatal = true to make the error pause the game
-                return 1 div 0
+            # intentional division by 0 error to showcase error catching behavior
+            return 1 div 0
         discard runCatchingTyped(
             fun = testErrorProc,
+            # use fatal = true to make the error pause the game
             fatal = false,
             messagePrefix = "Intentional Error: "
         )

--- a/playdate_example/src/playdate_example.nim
+++ b/playdate_example/src/playdate_example.nim
@@ -41,11 +41,11 @@ proc update(): int =
         let testErrorProc = proc(): int =
             # intentional division by 0 error to showcase error catching behavior
             return 1 div 0
-        discard runCatchingTyped(
-            fun = testErrorProc,
+        discard runCatching(
+            body = testErrorProc,
             # use fatal = true to make the error pause the game
             fatal = false,
-            messagePrefix = "Intentional Error: "
+            messagePrefix = "Intentional Error"
         )
 
     let goalX = x.toFloat

--- a/playdate_example/src/playdate_example.nim
+++ b/playdate_example/src/playdate_example.nim
@@ -39,7 +39,8 @@ proc update(): int =
 
     if kButtonB in buttonState.pushed:
         let testErrorProc = proc(): int =
-                # intentional division by 0 error
+                # intentional division by 0 error to showcase error catching behavior
+                # use fatal = true to make the error pause the game
                 return 1 div 0
         discard runCatchingTyped(
             fun = testErrorProc,

--- a/src/playdate/system.nim
+++ b/src/playdate/system.nim
@@ -54,7 +54,8 @@ template runCatching*(body: typed, fatal: bool = false, messagePrefix: string = 
         body()
     except Exception as e:
         logException(e, fatal, messagePrefix)
-        result # default value for inferred return type
+        when compiles(result): # result is only defined if body is a proc that has a return type
+            result # default value for inferred return type
 
 proc privateUpdate(userdata: pointer): cint {.cdecl.} =
     if updateCallback != nil:

--- a/src/playdate/system.nim
+++ b/src/playdate/system.nim
@@ -36,38 +36,28 @@ proc getSecondsSinceEpoch* (this: ptr PlaydateSys): tuple[seconds: uint, millise
 type PDCallbackFunction* = proc(): int {.raises: [].}
 var updateCallback: PDCallbackFunction = nil
 
-proc runCatchingTyped*[T](fun: () -> T, fatal: bool = false, messagePrefix: string=""): T =
+proc logException*(exception: ref Exception, fatal: bool = false, messagePrefix: string = "") =
+    ## if fatal is true, the game will pause
+    var message = &"{messagePrefix}: {exception.msg}\n{exception.getStackTrace()}"
+
+    for line in message.splitLines():
+        # Log the error to the console line-by-line, total stack trace might be too long for single call
+        playdate.system.logToConsole(line)
+
+    if fatal:
+        playdate.system.error("FATAL:" & exception.msg)
+
+template runCatching*(body: typed, fatal: bool = false, messagePrefix: string = ""): auto =
+    ## if fatal is true, the game will pause
     try:
-        return fun()
-    except:
-        let exception = getCurrentException()
-        var message: string = ""
-        try:
-            message = &"{messagePrefix}: {getCurrentExceptionMsg()}\n{exception.getStackTrace()}"
-        except:
-            message = getCurrentExceptionMsg() & exception.getStackTrace()
-
-        for line in message.splitLines():
-            # Log the error to the console line-by-line, total stack trace might be too long for single call
-            playdate.system.logToConsole(line)
-
-        if fatal:
-            playdate.system.error("FATAL:" & getCurrentExceptionMsg())
-
-proc runCatchingVoid*(fun: () -> void, fatal: bool = false, messagePrefix: string = "") =
-    let typedFun = proc(): int32 = 
-            fun()
-            return 0
-        
-    discard runCatchingTyped(
-        typedFun,
-        fatal,
-        messagePrefix
-    )
+        body()
+    except Exception as e:
+        logException(e, fatal, messagePrefix)
+        return result # default value for inferred return type
 
 proc privateUpdate(userdata: pointer): cint {.cdecl.} =
     if updateCallback != nil:
-        return runCatchingTyped(updateCallback, fatal = true).cint
+        return runCatching(body = updateCallback).cint
     else:
         playdate.system.error("No update callback defined.")
         return 0
@@ -76,7 +66,6 @@ proc setUpdateCallback*(this: ptr PlaydateSys, update: PDCallbackFunction) =
     privateAccess(PlaydateSys)
     updateCallback = update
     this.setUpdateCallback(privateUpdate, playdate)
-# ---
 
 proc getButtonState* (this: ptr PlaydateSys): tuple[current: PDButtons, pushed: PDButtons, released: PDButtons] =
     privateAccess(PlaydateSys)

--- a/src/playdate/system.nim
+++ b/src/playdate/system.nim
@@ -44,9 +44,6 @@ proc runCatchingTyped*[T](fun: () -> T, fatal: bool = false, messagePrefix: stri
         var message: string = ""
         try:
             message = &"{messagePrefix}: {getCurrentExceptionMsg()}\n{exception.getStackTrace()}"
-            # replace line number notation from (90) to :90, which is more common and can be picked up as source link in IDEs
-            message = message.replace('(', ':')
-            message = message.replace(")", "")
         except:
             message = getCurrentExceptionMsg() & exception.getStackTrace()
 

--- a/src/playdate/system.nim
+++ b/src/playdate/system.nim
@@ -44,14 +44,14 @@ proc runCatchingTyped*[T](fun: () -> T, fatal: bool = false, messagePrefix: stri
         var message: string = ""
         try:
             message = &"{messagePrefix}: {getCurrentExceptionMsg()}\n{exception.getStackTrace()}"
-            # replace line number notation from (90) to :90, which is more common and can be picked up as source link
+            # replace line number notation from (90) to :90, which is more common and can be picked up as source link in IDEs
             message = message.replace('(', ':')
             message = message.replace(")", "")
         except:
             message = getCurrentExceptionMsg() & exception.getStackTrace()
 
         for line in message.splitLines():
-            # Log the error to the console, total stack trace might be too long for single call
+            # Log the error to the console line-by-line, total stack trace might be too long for single call
             playdate.system.logToConsole(line)
 
         if fatal:
@@ -60,7 +60,7 @@ proc runCatchingTyped*[T](fun: () -> T, fatal: bool = false, messagePrefix: stri
 proc runCatchingVoid*(fun: () -> void, fatal: bool = false, messagePrefix: string = "") =
     let typedFun = proc(): int32 = 
             fun()
-            return 1
+            return 0
         
     discard runCatchingTyped(
         typedFun,

--- a/src/playdate/system.nim
+++ b/src/playdate/system.nim
@@ -12,6 +12,9 @@ export system
 {.hint[DuplicateModuleImport]: off.}
 import bindings/system {.all.}
 
+import std/sugar
+import std/strutils
+
 template fmt*(arg: typed): string =
     try: &(arg) except: arg
 
@@ -33,9 +36,41 @@ proc getSecondsSinceEpoch* (this: ptr PlaydateSys): tuple[seconds: uint, millise
 type PDCallbackFunction* = proc(): int {.raises: [].}
 var updateCallback: PDCallbackFunction = nil
 
+proc runCatchingTyped*[T](fun: () -> T, fatal: bool = false, messagePrefix: string=""): T =
+    try:
+        return fun()
+    except:
+        let exception = getCurrentException()
+        var message: string = ""
+        try:
+            message = &"{messagePrefix}: {getCurrentExceptionMsg()}\n{exception.getStackTrace()}"
+            # replace line number notation from (90) to :90, which is more common and can be picked up as source link
+            message = message.replace('(', ':')
+            message = message.replace(")", "")
+        except:
+            message = getCurrentExceptionMsg() & exception.getStackTrace()
+
+        for line in message.splitLines():
+            # Log the error to the console, total stack trace might be too long for single call
+            playdate.system.logToConsole(line)
+
+        if fatal:
+            playdate.system.error("FATAL:" & getCurrentExceptionMsg())
+
+proc runCatchingVoid*(fun: () -> void, fatal: bool = false, messagePrefix: string = "") =
+    let typedFun = proc(): int32 = 
+            fun()
+            return 1
+        
+    discard runCatchingTyped(
+        typedFun,
+        fatal,
+        messagePrefix
+    )
+
 proc privateUpdate(userdata: pointer): cint {.cdecl.} =
     if updateCallback != nil:
-        return updateCallback().cint
+        return runCatchingTyped(updateCallback, fatal = true).cint
     else:
         playdate.system.error("No update callback defined.")
         return 0

--- a/tests/t_system.nim
+++ b/tests/t_system.nim
@@ -12,6 +12,32 @@ proc execSystemTests*(runnable: bool)=
         let bgBitmap = playdate.graphics.newBitmap(400, 240, kColorBlack)
         playdate.system.setMenuImage(bgBitmap, 0)
 
+    test "runCatching typed int without exception":
+      var result: int
+      result = runCatching(proc(): int = 1)
+      assert(result == 1)
+
+    test "runCatching typed string without exception":
+      var result: string
+      result = runCatching(proc(): string = "test")
+      assert(result == "test")
+
+    test "runCatching typed bool without exception":
+      var result: bool
+      result = runCatching(proc(): bool = true)
+      assert(result == true)
+
+    # test "runCatching typed with exception":
+    #   var result: int
+    #   result = runCatching(proc(): int = raise newException(ValueError, "test"))
+    #   assert(result == 0)
+
+    test "runCatching untyped without exception":
+      runCatching(proc(): void = discard)
+
+    # test "runCatching untyped with exception":
+    #   runCatching(proc(): void = raise newException(ValueError, "test"))
+
 when isMainModule:
     # We can't run these methods from the tests, so we're only interested in
     # whether they compile.

--- a/tests/t_system.nim
+++ b/tests/t_system.nim
@@ -12,6 +12,18 @@ proc execSystemTests*(runnable: bool)=
         let bgBitmap = playdate.graphics.newBitmap(400, 240, kColorBlack)
         playdate.system.setMenuImage(bgBitmap, 0)
 
+    test "runCatching typed int with exception":
+      if(runnable):
+        var result: int
+        result = runCatching(proc(): int = raise newException(ValueError, "test Exveption with int return type"))
+        assert(result == 0)
+
+    test "runCatching untyped with exception":
+      if runnable:
+        runCatching(proc(): void = raise newException(ValueError, "test exception with void return type"))
+
+    # for the test cases below no logging to playdate console is needed, so they can be run on on any environment
+
     test "runCatching typed int without exception":
       var result: int
       result = runCatching(proc(): int = 1)
@@ -27,16 +39,8 @@ proc execSystemTests*(runnable: bool)=
       result = runCatching(proc(): bool = true)
       assert(result == true)
 
-    # test "runCatching typed with exception":
-    #   var result: int
-    #   result = runCatching(proc(): int = raise newException(ValueError, "test"))
-    #   assert(result == 0)
-
     test "runCatching untyped without exception":
       runCatching(proc(): void = discard)
-
-    # test "runCatching untyped with exception":
-    #   runCatching(proc(): void = raise newException(ValueError, "test"))
 
 when isMainModule:
     # We can't run these methods from the tests, so we're only interested in


### PR DESCRIPTION
## What is it

A proc that will execute a provided lambda and catch any errors. The exception is printed to the console.
Optionally, the error is marked as fatal, causing the simulator to be paused and the error message to be printed in red.

This is manly intended to add default error catching to the main update loop, but it can also be used in game code if desired. Sample usage is added

## Why
- I've been using this in Wheelsprung and it has been very helpful to me. At the same time this was super challenging to get working when you have no experience with Nim.
- Lowers the barrier of entry for transitioning from Lua to Nim as this provides behavior that is provided by the lua sdk but absent from a default C setup

## Challenges
- I wasn't sure how to wrap both procs that have a return type and procs without return type in a single wrapper, so I made 2
- I wanted to wrap the `handler` call in the `initSdk` macro too but that is executed very early in the boot sequence and I couldn't figure that out

## Out of scope
I plan a follow-up PR where the error is printed to the screen (device only, since simulator has the Console view). This provides a similar crash experience to the lua sdk and allows players to share a photo of the stacktrace with the dev, as is common practice for lua games.